### PR TITLE
Refactoring + E2E testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,11 @@ jobs:
         go-version: 1.23
     
     - name: Build
-      run: go build -x -v ./...
+      run: |
+        VERSION="${GITHUB_REF_NAME:-dev}"
+        COMMIT="${GITHUB_SHA:-none}"
+        DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+        go build -x -v -ldflags "-X github.com/orkes-io/conductor-cli/cmd.Version=${VERSION} -X github.com/orkes-io/conductor-cli/cmd.Commit=${COMMIT} -X github.com/orkes-io/conductor-cli/cmd.Date=${DATE}" ./...
     
     - name: Run tests
       run: go test -v -race -coverprofile=coverage.out -covermode=atomic -json ./... > test-results.json

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,55 @@
+name: E2E Tests
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
+jobs:
+  e2e-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: 1.23
+
+    - name: Build CLI
+      run: |
+        VERSION="${GITHUB_REF_NAME:-dev}"
+        COMMIT="${GITHUB_SHA:-none}"
+        DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+        go build -o orkes -v -ldflags "-X github.com/orkes-io/conductor-cli/cmd.Version=${VERSION} -X github.com/orkes-io/conductor-cli/cmd.Commit=${COMMIT} -X github.com/orkes-io/conductor-cli/cmd.Date=${DATE}" .
+        chmod +x orkes
+        ./orkes --version
+
+    - name: Setup bats
+      uses: bats-core/bats-action@2.0.0
+
+    - name: Run E2E tests
+      env:
+        CONDUCTOR_SERVER_URL: ${{ secrets.CONDUCTOR_SERVER_URL }}
+        CONDUCTOR_AUTH_KEY: ${{ secrets.CONDUCTOR_AUTH_KEY }}
+        CONDUCTOR_AUTH_SECRET: ${{ secrets.CONDUCTOR_AUTH_SECRET }}
+      run: |
+        bats test/e2e/workflow.bats
+
+    - name: Upload test artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: e2e-test-artifacts
+        path: |
+          test/e2e/*.log
+          test/e2e/*.json
+        if-no-files-found: ignore

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,7 +42,7 @@ jobs:
         CONDUCTOR_AUTH_KEY: ${{ secrets.CONDUCTOR_AUTH_KEY }}
         CONDUCTOR_AUTH_SECRET: ${{ secrets.CONDUCTOR_AUTH_SECRET }}
       run: |
-        bats test/e2e/workflow.bats
+        bats test/e2e/workflow.bats --show-output-of-passing-tests
 
     - name: Upload test artifacts
       if: always()

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ You must use **one** of the following authentication methods:
 
 ```bash
 # Option 1: API Key + Secret
-cdt --server http://localhost:8080/api --auth-key your-api-key --auth-secret your-api-secret workflow list
+orkes --server http://localhost:8080/api --auth-key your-api-key --auth-secret your-api-secret workflow list
 
 # Option 2: Auth Token (copy from UI)
-cdt --server http://localhost:8080/api --auth-token your-auth-token workflow list
+orkes --server http://localhost:8080/api --auth-token your-auth-token workflow list
 
 # Using config file
-cdt --config /path/to/config.yaml workflow list
+orkes --config /path/to/config.yaml workflow list
 ```
 
 ### Environment Variables
@@ -84,27 +84,27 @@ verbose: false
 You can also specify a custom config file location:
 
 ```bash
-cdt --config /path/to/my-config.yaml workflow list
+orkes --config /path/to/my-config.yaml workflow list
 ```
 
 ## Workflow Metadata Management
 
 ```shell
 # List the workflows on the server
-cdt workflow list
+orkes workflow list
 
 # Get the workflows definition - fetches the latest version
-cdt workflow get <workflowname>
+orkes workflow get <workflowname>
 
 # or you can specify a version
-cdt workflow get <workflowname> <version>
+orkes workflow get <workflowname> <version>
 
 # You can use quotes for workflow name if the name contains spaces, comma or special characters
-cdt workflow get "<workflow name with spaces>"
+orkes workflow get "<workflow name with spaces>"
 
 ```
 ### Create a workflow
 ```shell
 # Register a workflow stored in the file
-cdt workflow create /path/to/workflow_definition.json --force # use --force to overwrite existing
+orkes workflow create /path/to/workflow_definition.json --force # use --force to overwrite existing
 ```

--- a/README.md
+++ b/README.md
@@ -106,15 +106,5 @@ cdt workflow get "<workflow name with spaces>"
 ### Create a workflow
 ```shell
 # Register a workflow stored in the file
-cdt workflow create /path/to/workflow_definition.json --force # use --force to overwrite existing   
-```
-## Code Generation
-```shell
-# Generate a project of type (worker/application) in a particular language from a boilerplate (default is core)
-# See https://github.com/conductor-sdk/boilerplates for available boilerplates
-cdt code generate -n <name> -l <language> -t <type> -b <boilerplate>
-```
-Example:
-```shell
-cdt code generate -n myapp -l javascript -t worker
+cdt workflow create /path/to/workflow_definition.json --force # use --force to overwrite existing
 ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,7 +18,14 @@ import (
 	"time"
 )
 
-var NAME = "cdt"
+var (
+	// Version information - set via ldflags at build time
+	Version = "dev"
+	Commit  = "none"
+	Date    = "unknown"
+)
+
+var NAME = "orkes"
 
 var (
 	cfgFile string
@@ -30,9 +37,10 @@ var (
 	yes     bool
 )
 var rootCmd = &cobra.Command{
-	Use:   NAME,
-	Short: "cdt",
-	Long:  "CLI for Conductor",
+	Use:     NAME,
+	Short:   "orkes",
+	Long:    "CLI for Conductor",
+	Version: fmt.Sprintf("%s (commit: %s, built: %s)", Version, Commit, Date),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		// Suppress debug logs from conductor-go SDK at runtime
 		stdlog.SetOutput(io.Discard)

--- a/test/e2e/test-workflow.json
+++ b/test/e2e/test-workflow.json
@@ -1,5 +1,5 @@
 {
-  "name": "e2e_test_workflow",
+  "name": "cli_e2e_test_workflow",
   "description": "End-to-end test workflow with a simple wait task",
   "version": 1,
   "tasks": [

--- a/test/e2e/test-workflow.json
+++ b/test/e2e/test-workflow.json
@@ -1,0 +1,25 @@
+{
+  "name": "e2e_test_workflow",
+  "description": "End-to-end test workflow with a simple wait task",
+  "version": 1,
+  "tasks": [
+    {
+      "name": "wait_task",
+      "taskReferenceName": "wait_task_ref",
+      "inputParameters": {
+        "duration": "5 minutes"
+      },
+      "type": "WAIT",
+      "startDelay": 0,
+      "optional": false
+    }
+  ],
+  "inputParameters": [],
+  "outputParameters": {},
+  "schemaVersion": 2,
+  "restartable": true,
+  "workflowStatusListenerEnabled": false,
+  "ownerEmail": "test@example.com",
+  "timeoutPolicy": "ALERT_ONLY",
+  "timeoutSeconds": 0
+}

--- a/test/e2e/workflow.bats
+++ b/test/e2e/workflow.bats
@@ -3,7 +3,7 @@
 # E2E tests for conductor-cli
 # Tests must be run in order as they depend on each other
 
-WORKFLOW_NAME="e2e_test_workflow"
+WORKFLOW_NAME="cli_e2e_test_workflow"
 WORKFLOW_FILE="test/e2e/test-workflow.json"
 WORKFLOW_ID=""
 

--- a/test/e2e/workflow.bats
+++ b/test/e2e/workflow.bats
@@ -13,12 +13,6 @@ setup() {
         echo "ERROR: orkes binary not found. Please build it first."
         exit 1
     fi
-
-    # Verify required environment variables are set
-    if [ -z "$CONDUCTOR_SERVER_URL" ]; then
-        echo "ERROR: CONDUCTOR_SERVER_URL environment variable is not set"
-        exit 1
-    fi
 }
 
 # Helper function to extract workflow ID from execution start output
@@ -49,7 +43,7 @@ get_workflow_id() {
     WORKFLOW_ID=$(get_workflow_id "$output")
     [ -n "$WORKFLOW_ID" ]
     echo "$WORKFLOW_ID" > /tmp/workflow_id.txt
-    echo "Workflow ID: $WORKFLOW_ID"
+    echo "Started workflow UUID: $WORKFLOW_ID"
 }
 
 @test "4. Check workflow status is RUNNING" {
@@ -71,6 +65,7 @@ get_workflow_id() {
     run ./orkes execution terminate "$WORKFLOW_ID"
     echo "Output: $output"
     [ "$status" -eq 0 ]
+    echo "Terminated workflow UUID: $WORKFLOW_ID"
 }
 
 @test "6. Check workflow status is TERMINATED" {
@@ -95,6 +90,7 @@ get_workflow_id() {
     run ./orkes execution delete "$WORKFLOW_ID"
     echo "Output: $output"
     [ "$status" -eq 0 ]
+    echo "Deleted workflow UUID: $WORKFLOW_ID"
 }
 
 @test "8. Verify execution no longer exists" {

--- a/test/e2e/workflow.bats
+++ b/test/e2e/workflow.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+
+# E2E tests for conductor-cli
+# Tests must be run in order as they depend on each other
+
+WORKFLOW_NAME="e2e_test_workflow"
+WORKFLOW_FILE="test/e2e/test-workflow.json"
+WORKFLOW_ID=""
+
+setup() {
+    # Ensure the CLI binary exists
+    if [ ! -f "./orkes" ]; then
+        echo "ERROR: orkes binary not found. Please build it first."
+        exit 1
+    fi
+
+    # Verify required environment variables are set
+    if [ -z "$CONDUCTOR_SERVER_URL" ]; then
+        echo "ERROR: CONDUCTOR_SERVER_URL environment variable is not set"
+        exit 1
+    fi
+}
+
+# Helper function to extract workflow ID from execution start output
+get_workflow_id() {
+    echo "$1" | grep -oE '[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}'
+}
+
+@test "1. Create workflow definition" {
+    run ./orkes workflow create "$WORKFLOW_FILE" --force
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+}
+
+@test "2. Get workflow definition" {
+    run ./orkes workflow get "$WORKFLOW_NAME"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"$WORKFLOW_NAME"* ]]
+    [[ "$output" == *"wait_task"* ]]
+}
+
+@test "3. Start workflow execution" {
+    run ./orkes execution start --workflow "$WORKFLOW_NAME"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+
+    # Extract and save workflow ID
+    WORKFLOW_ID=$(get_workflow_id "$output")
+    [ -n "$WORKFLOW_ID" ]
+    echo "$WORKFLOW_ID" > /tmp/workflow_id.txt
+    echo "Workflow ID: $WORKFLOW_ID"
+}
+
+@test "4. Check workflow status is RUNNING" {
+    # Read the workflow ID from previous test
+    WORKFLOW_ID=$(cat /tmp/workflow_id.txt)
+    [ -n "$WORKFLOW_ID" ]
+
+    run ./orkes execution status "$WORKFLOW_ID"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    [[ "$output" == "RUNNING" ]]
+}
+
+@test "5. Terminate workflow execution" {
+    # Read the workflow ID from previous test
+    WORKFLOW_ID=$(cat /tmp/workflow_id.txt)
+    [ -n "$WORKFLOW_ID" ]
+
+    run ./orkes execution terminate "$WORKFLOW_ID"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+}
+
+@test "6. Check workflow status is TERMINATED" {
+    # Read the workflow ID from previous test
+    WORKFLOW_ID=$(cat /tmp/workflow_id.txt)
+    [ -n "$WORKFLOW_ID" ]
+
+    # Wait a moment for termination to process
+    sleep 2
+
+    run ./orkes execution status "$WORKFLOW_ID"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    [[ "$output" == "TERMINATED" ]]
+}
+
+@test "7. Delete workflow execution" {
+    # Read the workflow ID from previous test
+    WORKFLOW_ID=$(cat /tmp/workflow_id.txt)
+    [ -n "$WORKFLOW_ID" ]
+
+    run ./orkes execution delete "$WORKFLOW_ID"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+}
+
+@test "8. Verify execution no longer exists" {
+    # Read the workflow ID from previous test
+    WORKFLOW_ID=$(cat /tmp/workflow_id.txt)
+    [ -n "$WORKFLOW_ID" ]
+
+    # Wait a moment for deletion to process
+    sleep 2
+
+    run ./orkes execution status "$WORKFLOW_ID"
+    echo "Output: $output"
+    # Should fail since the execution was deleted
+    [ "$status" -ne 0 ]
+}
+
+@test "9. Cleanup - delete workflow definition" {
+    run ./orkes workflow delete "$WORKFLOW_NAME" 1
+    echo "Output: $output"
+    # Clean up the temp file
+    rm -f /tmp/workflow_id.txt
+}

--- a/version.go
+++ b/version.go
@@ -1,0 +1,7 @@
+package main
+
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)


### PR DESCRIPTION
## Changes in this PR
- Split workflow (metadata/definition) and execution commands i.e.: we now have `orkes workflow <sub-command> ...` and `orkes execution <sub-command> ...` to prevent collisions.
- Implementation of `orkes execution delete <uuid>`.
- Implementation of `orkes --version`. Will be set during releases/builds with `-ldflags`.
- Added E2E tests using [bats-core](https://github.com/bats-core/bats-core).
- Updated code and documentation to use `orkes` instead of `cdt`