### PR TITLE
Auto update command

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"runtime"
+
+	goupdater "github.com/inconshreveable/go-update"
+	"github.com/orkes-io/conductor-cli/internal/updater"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update the CLI to the latest version",
+	Long:  "Download and install the latest version of the Conductor CLI from GitHub releases.",
+	RunE:  runUpdate,
+}
+
+func init() {
+	rootCmd.AddCommand(updateCmd)
+}
+
+func runUpdate(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	fmt.Println("Checking for updates...")
+
+	// Check for latest version
+	updateInfo, err := updater.CheckForUpdate(ctx, Version)
+	if err != nil {
+		return fmt.Errorf("failed to check for updates: %w", err)
+	}
+
+	// Compare versions
+	if updater.CompareVersions(updateInfo.LatestVersion, Version) <= 0 {
+		fmt.Printf("✓ Already on the latest version: %s\n", Version)
+		return nil
+	}
+
+	fmt.Printf("Update available: %s → %s\n", Version, updateInfo.LatestVersion)
+
+	// Check if we have a download URL for this platform
+	if updateInfo.DownloadURL == "" {
+		fmt.Printf("\nNo pre-built binary available for %s/%s\n", runtime.GOOS, runtime.GOARCH)
+		fmt.Printf("Please download manually from: %s\n", updateInfo.ReleaseURL)
+		return nil
+	}
+
+	fmt.Printf("Downloading from: %s\n", updateInfo.DownloadURL)
+
+	// Download the binary
+	binaryData, err := updater.DownloadBinary(ctx, updateInfo.DownloadURL)
+	if err != nil {
+		return fmt.Errorf("failed to download binary: %w", err)
+	}
+
+	fmt.Printf("Downloaded %d bytes\n", len(binaryData))
+
+	// Apply the update (replace current binary)
+	fmt.Println("Applying update...")
+	err = goupdater.Apply(bytes.NewReader(binaryData), goupdater.Options{})
+	if err != nil {
+		// Check if it's a permissions error
+		if os.IsPermission(err) {
+			return fmt.Errorf("permission denied: try running with elevated privileges (sudo)")
+		}
+		return fmt.Errorf("failed to apply update: %w", err)
+	}
+
+	// Update the state file with the new version
+	state := &updater.UpdateState{
+		LatestVersion: updateInfo.LatestVersion,
+	}
+	if err := state.Save(); err != nil {
+		log.Warnf("Failed to update state file: %v", err)
+	}
+
+	fmt.Printf("✓ Successfully updated to %s\n", updateInfo.LatestVersion)
+	fmt.Println("\nPlease restart your terminal or run the command again to use the new version.")
+
+	return nil
+}

--- a/cmd/webhook_metadata.go
+++ b/cmd/webhook_metadata.go
@@ -52,7 +52,7 @@ var (
 	updateWebHookMetadataCmd = &cobra.Command{
 		Use:          "update <webhook_id>",
 		Short:        "Update Webhook",
-		RunE:         update,
+		RunE:         updateWebhook,
 		SilenceUsage: true,
 		Example:      "webhook update <webhook_id> --file webhook.json",
 	}
@@ -195,7 +195,7 @@ func create(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func update(cmd *cobra.Command, args []string) error {
+func updateWebhook(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
 		return cmd.Usage()
 	}

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
 	github.com/google/pprof v0.0.0-20230207041349-798e818bf904 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/ianlancetaylor/demangle v0.0.0-20220319035150-800ac71e25c2/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
+github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf h1:WfD7VjIE6z8dIvMsI4/s+1qr5EL+zoIGev1BQj1eoJ8=
+github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf/go.mod h1:hyb9oH7vZsitZCiBt0ZvifOrB+qc8PS5IiilCIb87rg=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/internal/updater/checker.go
+++ b/internal/updater/checker.go
@@ -1,0 +1,175 @@
+package updater
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"runtime"
+	"time"
+)
+
+const (
+	githubRepo        = "conductor-oss/conductor-cli"
+	githubAPITimeout  = 10 * time.Second
+	releasesAPIURL    = "https://api.github.com/repos/" + githubRepo + "/releases/latest"
+)
+
+// UpdateInfo contains information about an available update
+type UpdateInfo struct {
+	LatestVersion string
+	CurrentVersion string
+	DownloadURL   string
+	ReleaseURL    string
+}
+
+// GitHubRelease represents the GitHub API response for a release
+type GitHubRelease struct {
+	TagName string `json:"tag_name"`
+	Assets  []struct {
+		Name               string `json:"name"`
+		BrowserDownloadURL string `json:"browser_download_url"`
+	} `json:"assets"`
+	HTMLURL string `json:"html_url"`
+}
+
+// CheckForUpdate checks GitHub for the latest release
+func CheckForUpdate(ctx context.Context, currentVersion string) (*UpdateInfo, error) {
+	ctx, cancel := context.WithTimeout(ctx, githubAPITimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", releasesAPIURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set User-Agent header (GitHub API requirement)
+	req.Header.Set("User-Agent", "conductor-cli")
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("github api returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var release GitHubRelease
+	if err := json.Unmarshal(body, &release); err != nil {
+		return nil, err
+	}
+
+	// Find the appropriate asset for current platform
+	assetName := getAssetName()
+	downloadURL := ""
+	for _, asset := range release.Assets {
+		if asset.Name == assetName {
+			downloadURL = asset.BrowserDownloadURL
+			break
+		}
+	}
+
+	return &UpdateInfo{
+		LatestVersion:  release.TagName,
+		CurrentVersion: currentVersion,
+		DownloadURL:    downloadURL,
+		ReleaseURL:     release.HTMLURL,
+	}, nil
+}
+
+// CheckInBackground performs a background check and updates the state file
+func CheckInBackground(ctx context.Context, currentVersion string) {
+	go func() {
+		state, err := LoadState()
+		if err != nil {
+			// Silently fail - don't block CLI
+			return
+		}
+
+		if !state.ShouldCheck() {
+			return
+		}
+
+		updateInfo, err := CheckForUpdate(ctx, currentVersion)
+		if err != nil {
+			// Silently fail - don't block CLI or spam errors
+			// Just update the timestamp so we don't retry immediately
+			state.LastCheck = time.Now()
+			_ = state.Save()
+			return
+		}
+
+		// Update state
+		state.LastCheck = time.Now()
+		state.LatestVersion = updateInfo.LatestVersion
+		_ = state.Save()
+	}()
+}
+
+// ShouldNotifyUpdate checks if we should notify the user about an update
+func ShouldNotifyUpdate(currentVersion string) (bool, string) {
+	state, err := LoadState()
+	if err != nil {
+		return false, ""
+	}
+
+	if state.HasUpdate(currentVersion) {
+		return true, state.LatestVersion
+	}
+
+	return false, ""
+}
+
+// getAssetName returns the expected asset name for the current platform
+func getAssetName() string {
+	// Format: orkes_<os>_<arch> or orkes_<os>_<arch>.exe for windows
+	osName := runtime.GOOS
+	archName := runtime.GOARCH
+
+	// Map Go arch names to common naming conventions
+	switch archName {
+	case "amd64":
+		archName = "x86_64"
+	case "arm64":
+		archName = "arm64"
+	}
+
+	assetName := fmt.Sprintf("orkes_%s_%s", osName, archName)
+
+	if runtime.GOOS == "windows" {
+		assetName += ".exe"
+	}
+
+	return assetName
+}
+
+// DownloadBinary downloads the binary from the given URL
+func DownloadBinary(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("download failed with status %d", resp.StatusCode)
+	}
+
+	return io.ReadAll(resp.Body)
+}

--- a/internal/updater/state.go
+++ b/internal/updater/state.go
@@ -1,0 +1,137 @@
+package updater
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	configDirName      = ".conductor-cli"
+	updateStateFile    = "update-check.json"
+	checkInterval      = 24 * time.Hour
+)
+
+// UpdateState represents the state of update checks
+type UpdateState struct {
+	LastCheck     time.Time `json:"last_check"`
+	LatestVersion string    `json:"latest_version,omitempty"`
+}
+
+// GetConfigDir returns the path to the CLI config directory (~/.conductor-cli)
+func GetConfigDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, configDirName), nil
+}
+
+// GetConfigFile returns the path to the main config file
+func GetConfigFile() (string, error) {
+	configDir, err := GetConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(configDir, "config.yaml"), nil
+}
+
+// GetUpdateStateFile returns the path to the update state file
+func GetUpdateStateFile() (string, error) {
+	configDir, err := GetConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(configDir, updateStateFile), nil
+}
+
+// LoadState loads the update state from disk
+func LoadState() (*UpdateState, error) {
+	stateFile, err := GetUpdateStateFile()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(stateFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Return empty state if file doesn't exist
+			return &UpdateState{}, nil
+		}
+		return nil, err
+	}
+
+	var state UpdateState
+	if err := json.Unmarshal(data, &state); err != nil {
+		// If corrupted, return empty state
+		return &UpdateState{}, nil
+	}
+
+	return &state, nil
+}
+
+// Save saves the update state to disk
+func (s *UpdateState) Save() error {
+	configDir, err := GetConfigDir()
+	if err != nil {
+		return err
+	}
+
+	// Create config directory if it doesn't exist
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return err
+	}
+
+	stateFile, err := GetUpdateStateFile()
+	if err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(stateFile, data, 0644)
+}
+
+// ShouldCheck returns true if enough time has passed since the last check
+func (s *UpdateState) ShouldCheck() bool {
+	if s.LastCheck.IsZero() {
+		return true
+	}
+	return time.Since(s.LastCheck) >= checkInterval
+}
+
+// HasUpdate returns true if a newer version is available
+func (s *UpdateState) HasUpdate(currentVersion string) bool {
+	if s.LatestVersion == "" {
+		return false
+	}
+	return CompareVersions(s.LatestVersion, currentVersion) > 0
+}
+
+// CompareVersions compares two version strings (simple semver comparison)
+// Returns: 1 if v1 > v2, -1 if v1 < v2, 0 if equal
+func CompareVersions(v1, v2 string) int {
+	// Remove 'v' prefix if present
+	v1 = trimPrefix(v1, "v")
+	v2 = trimPrefix(v2, "v")
+
+	// Simple comparison for now (can be enhanced with proper semver library)
+	if v1 == v2 {
+		return 0
+	}
+	if v1 > v2 {
+		return 1
+	}
+	return -1
+}
+
+func trimPrefix(s, prefix string) string {
+	if len(s) > 0 && s[0:1] == prefix {
+		return s[1:]
+	}
+	return s
+}


### PR DESCRIPTION
## Changes in this PR
1. Changed the config file location to a dir `~/.conductor-cli`.
2. Every 24 hours the cli checks if there is a newer version and notifies the user. A timestamp is kept in a file in the config dir.
3. Auto update command (with github.com/inconshreveable/go-update).

**NOTES**
Merging the auto update changes but required more testing.