### PR TITLE
Fixes related to tests and update notification

### DIFF
--- a/internal/updater/state.go
+++ b/internal/updater/state.go
@@ -110,7 +110,7 @@ func (s *UpdateState) HasUpdate(currentVersion string) bool {
 		return false
 	}
 	// Never show update notification for dev builds
-	if currentVersion == "dev" {
+	if currentVersion == "dev" || currentVersion == "main" {
 		return false
 	}
 	return CompareVersions(s.LatestVersion, currentVersion) > 0

--- a/internal/updater/state_test.go
+++ b/internal/updater/state_test.go
@@ -252,6 +252,12 @@ func TestHasUpdate(t *testing.T) {
 			currentVersion: "dev",
 			expected:       false,
 		},
+		{
+			name:           "main version never shows update",
+			latestVersion:  "v0.0.10",
+			currentVersion: "main",
+			expected:       false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/test/e2e/rerun.bats
+++ b/test/e2e/rerun.bats
@@ -20,13 +20,13 @@ get_workflow_id() {
 }
 
 @test "1. Create test workflow definition" {
-    run ./orkes workflow create "$WORKFLOW_FILE" --force
+    run bash -c "./orkes workflow create '$WORKFLOW_FILE' --force 2>/dev/null"
     echo "Output: $output"
     [ "$status" -eq 0 ]
 }
 
 @test "2. Start workflow execution" {
-    run ./orkes execution start --workflow "$WORKFLOW_NAME"
+    run bash -c "./orkes execution start --workflow '$WORKFLOW_NAME' 2>/dev/null"
     echo "Output: $output"
     [ "$status" -eq 0 ]
 
@@ -44,7 +44,7 @@ get_workflow_id() {
 
     # Wait up to 10 seconds for workflow to complete
     for i in {1..10}; do
-        run ./orkes execution status "$WORKFLOW_ID"
+        run bash -c "./orkes execution status '$WORKFLOW_ID' 2>/dev/null"
         echo "Attempt $i: Status = $output"
 
         if [ "$output" = "COMPLETED" ]; then
@@ -61,7 +61,7 @@ get_workflow_id() {
     WORKFLOW_ID=$(cat /tmp/rerun_workflow_id.txt)
     [ -n "$WORKFLOW_ID" ]
 
-    run ./orkes execution get "$WORKFLOW_ID"
+    run bash -c "./orkes execution get '$WORKFLOW_ID' 2>/dev/null"
     echo "Output: $output"
     [ "$status" -eq 0 ]
 
@@ -73,7 +73,7 @@ get_workflow_id() {
     WORKFLOW_ID=$(cat /tmp/rerun_workflow_id.txt)
     [ -n "$WORKFLOW_ID" ]
 
-    run ./orkes execution rerun "$WORKFLOW_ID"
+    run bash -c "./orkes execution rerun '$WORKFLOW_ID' 2>/dev/null"
     echo "Output: $output"
     [ "$status" -eq 0 ]
 
@@ -92,7 +92,7 @@ get_workflow_id() {
 
     # Wait up to 10 seconds for rerun workflow to complete
     for i in {1..10}; do
-        run ./orkes execution status "$WORKFLOW_ID"
+        run bash -c "./orkes execution status '$WORKFLOW_ID' 2>/dev/null"
         echo "Attempt $i: Rerun status = $output"
 
         if [ "$output" = "COMPLETED" ]; then
@@ -109,14 +109,14 @@ get_workflow_id() {
     WORKFLOW_ID=$(cat /tmp/rerun_workflow_id.txt)
     [ -n "$WORKFLOW_ID" ]
 
-    run ./orkes execution delete "$WORKFLOW_ID"
+    run bash -c "./orkes execution delete '$WORKFLOW_ID' 2>/dev/null"
     echo "Output: $output"
     [ "$status" -eq 0 ]
     echo "Deleted workflow UUID: $WORKFLOW_ID"
 }
 
 @test "8. Cleanup - Delete workflow definition" {
-    run ./orkes workflow delete "$WORKFLOW_NAME" 1
+    run bash -c "./orkes workflow delete '$WORKFLOW_NAME' 1 2>/dev/null"
     echo "Output: $output"
     [ "$status" -eq 0 ]
 }

--- a/test/e2e/webhook.bats
+++ b/test/e2e/webhook.bats
@@ -20,12 +20,12 @@ get_webhook_id() {
 }
 
 @test "1. Create webhook using command flags" {
-    run ./orkes webhook create \
+    run bash -c "./orkes webhook create \
         --name custom_webhook_1 \
         --source-platform Custom \
         --verifier HEADER_BASED \
-        --headers "Authorization:BB12346789" \
-        --receiver-workflows hello_world:1
+        --headers 'Authorization:BB12346789' \
+        --receiver-workflows hello_world:1 2>/dev/null"
     echo "Output: $output"
     [ "$status" -eq 0 ]
 
@@ -43,7 +43,7 @@ get_webhook_id() {
     WEBHOOK_ID=$(cat /tmp/webhook_test_id.txt)
     [ -n "$WEBHOOK_ID" ]
 
-    run ./orkes webhook get "$WEBHOOK_ID"
+    run bash -c "./orkes webhook get '$WEBHOOK_ID' 2>/dev/null"
     echo "Output: $output"
     [ "$status" -eq 0 ]
 
@@ -57,7 +57,7 @@ get_webhook_id() {
     WEBHOOK_ID=$(cat /tmp/webhook_test_id.txt)
     [ -n "$WEBHOOK_ID" ]
 
-    run ./orkes webhook list
+    run bash -c "./orkes webhook list 2>/dev/null"
     echo "Output: $output"
     [ "$status" -eq 0 ]
 
@@ -70,7 +70,7 @@ get_webhook_id() {
     WEBHOOK_ID=$(cat /tmp/webhook_test_id.txt)
     [ -n "$WEBHOOK_ID" ]
 
-    run ./orkes webhook list --json
+    run bash -c "./orkes webhook list --json 2>/dev/null"
     echo "Output: $output"
     [ "$status" -eq 0 ]
 
@@ -98,7 +98,7 @@ get_webhook_id() {
 }
 EOF
 
-    run ./orkes webhook update "$WEBHOOK_ID" --file /tmp/webhook_update.json
+    run bash -c "./orkes webhook update '$WEBHOOK_ID' --file /tmp/webhook_update.json 2>/dev/null"
     echo "Output: $output"
     [ "$status" -eq 0 ]
 
@@ -110,7 +110,7 @@ EOF
     WEBHOOK_ID=$(cat /tmp/webhook_test_id.txt)
     [ -n "$WEBHOOK_ID" ]
 
-    run ./orkes webhook get "$WEBHOOK_ID"
+    run bash -c "./orkes webhook get '$WEBHOOK_ID' 2>/dev/null"
     echo "Output: $output"
     [ "$status" -eq 0 ]
 
@@ -124,7 +124,7 @@ EOF
     WEBHOOK_ID=$(cat /tmp/webhook_test_id.txt)
     [ -n "$WEBHOOK_ID" ]
 
-    run ./orkes webhook delete "$WEBHOOK_ID"
+    run bash -c "./orkes webhook delete '$WEBHOOK_ID' 2>/dev/null"
     echo "Output: $output"
     [ "$status" -eq 0 ]
 
@@ -137,7 +137,7 @@ EOF
     [ -n "$WEBHOOK_ID" ]
 
     # Getting deleted webhook should fail
-    run ./orkes webhook get "$WEBHOOK_ID"
+    run bash -c "./orkes webhook get '$WEBHOOK_ID' 2>/dev/null"
     echo "Output: $output"
     [ "$status" -ne 0 ]
 }

--- a/test/e2e/workflow.bats
+++ b/test/e2e/workflow.bats
@@ -21,13 +21,13 @@ get_workflow_id() {
 }
 
 @test "1. Create workflow definition" {
-    run ./orkes workflow create "$WORKFLOW_FILE" --force
+    run bash -c "./orkes workflow create '$WORKFLOW_FILE' --force 2>/dev/null"
     echo "Output: $output"
     [ "$status" -eq 0 ]
 }
 
 @test "2. Get workflow definition" {
-    run ./orkes workflow get "$WORKFLOW_NAME"
+    run bash -c "./orkes workflow get '$WORKFLOW_NAME' 2>/dev/null"
     echo "Output: $output"
     [ "$status" -eq 0 ]
     [[ "$output" == *"$WORKFLOW_NAME"* ]]
@@ -35,7 +35,7 @@ get_workflow_id() {
 }
 
 @test "3. Start workflow execution" {
-    run ./orkes execution start --workflow "$WORKFLOW_NAME"
+    run bash -c "./orkes execution start --workflow '$WORKFLOW_NAME' 2>/dev/null"
     echo "Output: $output"
     [ "$status" -eq 0 ]
 
@@ -51,7 +51,7 @@ get_workflow_id() {
     WORKFLOW_ID=$(cat /tmp/workflow_id.txt)
     [ -n "$WORKFLOW_ID" ]
 
-    run ./orkes execution status "$WORKFLOW_ID"
+    run bash -c "./orkes execution status '$WORKFLOW_ID' 2>/dev/null"
     echo "Output: $output"
     [ "$status" -eq 0 ]
     [[ "$output" == "RUNNING" ]]
@@ -62,7 +62,7 @@ get_workflow_id() {
     WORKFLOW_ID=$(cat /tmp/workflow_id.txt)
     [ -n "$WORKFLOW_ID" ]
 
-    run ./orkes execution terminate "$WORKFLOW_ID"
+    run bash -c "./orkes execution terminate '$WORKFLOW_ID' 2>/dev/null"
     echo "Output: $output"
     [ "$status" -eq 0 ]
     echo "Terminated workflow UUID: $WORKFLOW_ID"
@@ -76,7 +76,7 @@ get_workflow_id() {
     # Wait a moment for termination to process
     sleep 2
 
-    run ./orkes execution status "$WORKFLOW_ID"
+    run bash -c "./orkes execution status '$WORKFLOW_ID' 2>/dev/null"
     echo "Output: $output"
     [ "$status" -eq 0 ]
     [[ "$output" == "TERMINATED" ]]
@@ -87,7 +87,7 @@ get_workflow_id() {
     WORKFLOW_ID=$(cat /tmp/workflow_id.txt)
     [ -n "$WORKFLOW_ID" ]
 
-    run ./orkes execution delete "$WORKFLOW_ID"
+    run bash -c "./orkes execution delete '$WORKFLOW_ID' 2>/dev/null"
     echo "Output: $output"
     [ "$status" -eq 0 ]
     echo "Deleted workflow UUID: $WORKFLOW_ID"
@@ -101,14 +101,14 @@ get_workflow_id() {
     # Wait a moment for deletion to process
     sleep 2
 
-    run ./orkes execution status "$WORKFLOW_ID"
+    run bash -c "./orkes execution status '$WORKFLOW_ID' 2>/dev/null"
     echo "Output: $output"
     # Should fail since the execution was deleted
     [ "$status" -ne 0 ]
 }
 
 @test "9. Cleanup - delete workflow definition" {
-    run ./orkes workflow delete "$WORKFLOW_NAME" 1
+    run bash -c "./orkes workflow delete '$WORKFLOW_NAME' 1 2>/dev/null"
     echo "Output: $output"
     # Clean up the temp file
     rm -f /tmp/workflow_id.txt


### PR DESCRIPTION
run tests like `run bash -c "./orkes workflow create '$WORKFLOW_FILE' --force 2>/dev/null"` to redirect stderr to `/dev/null` to fix failing tests. E.g.: https://github.com/conductor-oss/conductor-cli/actions/runs/18357687893/job/52293821715
