### PR TITLE
Added support for profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ export CONDUCTOR_AUTH_TOKEN=your-auth-token
 
 ### Configuration File
 
-Create a `.conductor-cli.yaml` file in your home directory (`$HOME/.conductor-cli.yaml`).
+Configuration files are stored in `~/.conductor-cli/` directory.
 
 **Authentication Options:**
 
@@ -155,6 +155,60 @@ You can also specify a custom config file location:
 
 ```bash
 orkes --config /path/to/my-config.yaml workflow list
+```
+
+### Profiles
+
+Profiles allow you to manage multiple Conductor environments (e.g., development, staging, production) easily.
+
+**Creating a Profile:**
+
+Save your current flags to a named profile:
+
+```bash
+# Save to default profile (~/.conductor-cli/config.yaml)
+orkes --server https://dev.example.com --auth-key key123 --save-config workflow list
+
+# Save to named profile (~/.conductor-cli/config-production.yaml)
+orkes --server https://prod.example.com --auth-token token --save-config=production workflow list
+
+# Create multiple profiles
+orkes --server https://staging.example.com --auth-key key --save-config=staging workflow list
+```
+
+**Using a Profile:**
+
+Load configuration from a specific profile:
+
+```bash
+# Using --profile flag
+orkes --profile production workflow list
+
+# Using ORKES_PROFILE environment variable
+export ORKES_PROFILE=production
+orkes workflow list
+
+# Flag takes precedence over environment variable
+ORKES_PROFILE=staging orkes --profile production workflow list  # Uses production
+```
+
+**Profile File Structure:**
+
+```
+~/.conductor-cli/
+├── config.yaml              # Default profile
+├── config-production.yaml   # Production profile
+├── config-staging.yaml      # Staging profile
+└── config-dev.yaml          # Development profile
+```
+
+**Profile Error Handling:**
+
+If you reference a profile that doesn't exist, you'll get a clear error:
+
+```bash
+orkes --profile nonexistent workflow list
+# Error: Profile 'nonexistent' doesn't exist (expected file: ~/.conductor-cli/config-nonexistent.yaml)
 ```
 
 ## Workflow Metadata Management

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -205,14 +205,20 @@ func initConfig() {
 		viper.AddConfigPath(configDir)
 		viper.SetConfigType("yaml")
 
-		// Use profile-specific config if --profile is set
-		if profile != "" {
-			configName := fmt.Sprintf("config-%s", profile)
+		// Determine which profile to use: --profile flag takes precedence over ORKES_PROFILE env var
+		activeProfile := profile
+		if activeProfile == "" {
+			activeProfile = os.Getenv("ORKES_PROFILE")
+		}
+
+		// Use profile-specific config if profile is set
+		if activeProfile != "" {
+			configName := fmt.Sprintf("config-%s", activeProfile)
 			configPath := filepath.Join(configDir, configName+".yaml")
 
 			// Check if profile config exists
 			if _, err := os.Stat(configPath); os.IsNotExist(err) {
-				fmt.Fprintf(os.Stderr, "Error: Profile '%s' doesn't exist (expected file: %s)\n", profile, configPath)
+				fmt.Fprintf(os.Stderr, "Error: Profile '%s' doesn't exist (expected file: %s)\n", activeProfile, configPath)
 				os.Exit(1)
 			}
 
@@ -259,7 +265,7 @@ func init() {
 	rootCmd.PersistentFlags().String("auth-token", "", "Auth token for authentication (can also be set via CONDUCTOR_AUTH_TOKEN)")
 
 	// Profile and config management flags
-	rootCmd.PersistentFlags().StringVar(&profile, "profile", "", "use a specific profile (loads config-<profile>.yaml)")
+	rootCmd.PersistentFlags().StringVar(&profile, "profile", "", "use a specific profile (loads config-<profile>.yaml, can also be set via ORKES_PROFILE)")
 	rootCmd.PersistentFlags().StringVar(&saveConfig, "save-config", "", "save current flags to config file (optionally specify profile name)")
 
 	// Other flags


### PR DESCRIPTION
## Change in this PR
1. Users can persist their config (server url + credentials) using `--save-config` flag (persisted to `~/.conductor-cli/config.yaml or config-<profile>.yaml`)
2. User can use profiles to have different configs.