### PR TITLE
Experimental - CLI JS worker

### DIFF
--- a/CLI_JS_WORKER.md
+++ b/CLI_JS_WORKER.md
@@ -1,0 +1,449 @@
+# JavaScript Worker for Conductor CLI
+
+⚠️ **EXPERIMENTAL FEATURE** - This feature is experimental and may change in future releases.
+
+The `orkes worker run` command allows you to run JavaScript workers that poll for tasks and execute custom JavaScript code to process them.
+
+## Overview
+
+The JavaScript worker:
+- Continuously polls for tasks of a specific type
+- Executes a JavaScript file for each task
+- Processes tasks in parallel using goroutines
+- Automatically updates task status based on script execution results
+
+## Usage
+
+```bash
+orkes worker run --type <task_type> <js_file>
+```
+
+### Required Arguments
+
+- `<js_file>` - Path to the JavaScript file to execute for each task
+- `--type` - Task type to poll for (required flag)
+
+### Optional Flags
+
+- `--count` - Number of tasks to poll in each batch (default: 1)
+- `--worker-id` - Worker ID for identification
+- `--domain` - Domain for task polling
+- `--timeout` - Timeout in milliseconds (default: 100)
+
+### Example
+
+```bash
+orkes worker run --type process_order --worker-id worker1 --count 5 worker.js
+```
+
+## JavaScript Worker Script
+
+Your JavaScript file will be executed for each polled task. The task data is available via the `$.task` global object.
+
+### Simple Example
+
+```javascript
+// worker.js - Simple task processor
+(function() {
+  var input = $.task.inputData;
+
+  // Process the input
+  var result = {
+    processed: true,
+    originalData: input
+  };
+
+  // Return result
+  return {
+    status: "COMPLETED",
+    body: result
+  };
+})();
+```
+
+### Fetching External Data
+
+```javascript
+// worker.js - Fetch a cat fact from an API
+(function() {
+  // Make HTTP GET request
+  var response = http.get("https://catfact.ninja/fact", {});
+
+  // Check for errors
+  if (response.error) {
+    return {
+      status: "FAILED",
+      body: { error: "Failed to fetch cat fact: " + response.error }
+    };
+  }
+
+  // Check HTTP status
+  if (response.status !== 200) {
+    return {
+      status: "FAILED",
+      body: { error: "HTTP error: " + response.status }
+    };
+  }
+
+  // Extract just the fact field
+  var catFact = response.body.fact;
+
+  // Return success with the fact
+  return {
+    status: "COMPLETED",
+    body: {
+      fact: catFact,
+      taskId: $.task.taskId,
+      fetchedAt: new Date().toISOString()
+    }
+  };
+})();
+```
+
+**Note:** Workers must use a self-invoking function `(function() { ... })()` or define and call a function to use `return` statements.
+
+### Returning Status and Output
+
+Your script can return an object with `status` and `body` fields to control the task outcome:
+
+```javascript
+// worker.js - Return custom status and output
+(function() {
+  var input = $.task.inputData;
+
+  function processOrder(orderId) {
+    // Your business logic here
+    return { success: true, trackingNumber: "TRK-" + orderId };
+  }
+
+  try {
+    // Process the task
+    var result = processOrder(input.orderId);
+
+    // Return success with output
+    return {
+      status: "COMPLETED",
+      body: {
+        orderId: input.orderId,
+        result: result,
+        processedAt: new Date().toISOString()
+      }
+    };
+  } catch (error) {
+    // Return failure with error details
+    return {
+      status: "FAILED",
+      body: {
+        error: error.message,
+        orderId: input.orderId
+      }
+    };
+  }
+})();
+```
+
+### Status Values
+
+The `status` field can be one of:
+- `COMPLETED` - Task completed successfully
+- `FAILED` - Task failed
+- `FAILED_WITH_TERMINAL_ERROR` - Task failed with terminal error (no retries)
+- `IN_PROGRESS` - Task is still in progress
+
+### Return Value Behavior
+
+| Return Value | Behavior |
+|-------------|----------|
+| `{status: "...", body: {...}}` | Updates task with specified status and output data |
+| Any other value | Task marked as COMPLETED with the value in output |
+| No return value (undefined) | Task marked as COMPLETED with empty output |
+| Script throws error | Task marked as FAILED with error message |
+
+## The $.task Object
+
+The `$.task` object contains all information about the current task being processed.
+
+### Key Fields
+
+#### Task Identification
+- `taskId` (string) - Unique identifier for this task
+- `taskType` (string) - Type of the task
+- `referenceTaskName` (string) - Reference name from workflow definition
+- `taskDefName` (string) - Task definition name
+
+#### Workflow Context
+- `workflowInstanceId` (string) - ID of the workflow instance this task belongs to
+- `workflowType` (string) - Type of the workflow
+- `correlationId` (string) - Correlation ID for tracking
+- `workflowPriority` (number) - Priority of the workflow
+
+#### Task Data
+- `inputData` (object) - Input data for the task (most commonly used)
+- `outputData` (object) - Output data from the task
+- `status` (string) - Current status of the task
+
+#### Execution Details
+- `workerId` (string) - ID of the worker processing this task
+- `pollCount` (number) - Number of times this task has been polled
+- `retryCount` (number) - Number of times this task has been retried
+- `seq` (number) - Sequence number in the workflow
+
+#### Timing Information
+- `scheduledTime` (number) - When the task was scheduled (epoch milliseconds)
+- `startTime` (number) - When the task started (epoch milliseconds)
+- `endTime` (number) - When the task ended (epoch milliseconds)
+- `updateTime` (number) - Last update time (epoch milliseconds)
+- `queueWaitTime` (number) - Time spent in queue (milliseconds)
+
+#### Configuration
+- `responseTimeoutSeconds` (number) - Response timeout in seconds
+- `callbackAfterSeconds` (number) - Callback delay in seconds
+- `startDelayInSeconds` (number) - Start delay in seconds
+
+#### State Flags
+- `retried` (boolean) - Whether this task has been retried
+- `executed` (boolean) - Whether this task has been executed
+- `callbackFromWorker` (boolean) - Whether callback is from worker
+- `loopOverTask` (boolean) - Whether this is a loop task
+
+#### Advanced Fields
+- `domain` (string) - Domain for the task
+- `isolationGroupId` (string) - Isolation group identifier
+- `executionNameSpace` (string) - Execution namespace
+- `subWorkflowId` (string) - Sub-workflow ID if this task spawned a sub-workflow
+- `iteration` (number) - Iteration number for loop tasks
+- `taskDefinition` (object) - Full task definition metadata
+- `workflowTask` (object) - Workflow task definition
+
+### Example: Accessing Task Data
+
+```javascript
+// worker.js - Using various task fields
+(function() {
+  var task = $.task;
+
+  // Access input data
+  var orderId = task.inputData.orderId;
+  var customerName = task.inputData.customerName;
+
+  // Calculate processing time
+  var startTime = new Date(task.startTime);
+  var now = new Date();
+  var processingTime = now - startTime;
+
+  // Return result
+  return {
+    status: "COMPLETED",
+    body: {
+      taskId: task.taskId,
+      workflowId: task.workflowInstanceId,
+      taskType: task.taskType,
+      orderId: orderId,
+      customerName: customerName,
+      processingTime: processingTime,
+      retryCount: task.retryCount,
+      isRetry: task.retryCount > 0
+    }
+  };
+})();
+```
+
+## Error Handling
+
+If your script throws an error, the task is automatically marked as FAILED:
+
+```javascript
+// worker.js - Error handling
+(function() {
+  function riskyOperation(data) {
+    // Your risky operation here
+    if (!data) throw new Error("No data provided");
+    return { processed: data };
+  }
+
+  try {
+    var result = riskyOperation($.task.inputData);
+
+    return {
+      status: "COMPLETED",
+      body: result
+    };
+  } catch (error) {
+    // Return explicit failure
+    return {
+      status: "FAILED",
+      body: {
+        error: error.message,
+        stack: error.stack
+      }
+    };
+  }
+})();
+```
+
+## Best Practices
+
+1. **Always validate input data**
+   ```javascript
+   (function() {
+     var input = $.task.inputData;
+     if (!input.orderId) {
+       return {
+         status: "FAILED",
+         body: { error: "Missing orderId in input" }
+       };
+     }
+     // ... rest of your code
+   })();
+   ```
+
+2. **Use try-catch for error handling**
+   ```javascript
+   (function() {
+     try {
+       // Your logic
+     } catch (error) {
+       return { status: "FAILED", body: { error: error.message } };
+     }
+   })();
+   ```
+
+3. **Return meaningful output**
+   ```javascript
+   (function() {
+     var processedData = { /* ... */ };
+     return {
+       status: "COMPLETED",
+       body: {
+         result: processedData,
+         timestamp: new Date().toISOString(),
+         workerId: $.task.workerId
+       }
+     };
+   })();
+   ```
+
+4. **Handle retries gracefully**
+   ```javascript
+   (function() {
+     if ($.task.retryCount > 3) {
+       return {
+         status: "FAILED_WITH_TERMINAL_ERROR",
+         body: { error: "Max retries exceeded" }
+       };
+     }
+     // ... rest of your code
+   })();
+   ```
+
+## Parallel Processing
+
+The worker processes multiple tasks in parallel using goroutines. Each task is executed in its own JavaScript VM instance, so there's no shared state between tasks.
+
+```bash
+# Poll 10 tasks at a time and process them in parallel
+orkes worker run --type my_task --count 10 worker.js
+```
+
+## Continuous Polling
+
+The worker runs in a continuous loop, polling for tasks and processing them until you stop it (Ctrl+C).
+
+## Logging
+
+The worker logs important events at the Go level:
+- Task polling (how many tasks polled)
+- Task processing start
+- Task completion/failure
+- Errors during script execution
+
+Use `--verbose` flag for debug logging:
+```bash
+orkes --verbose worker run --type my_task worker.js
+```
+
+**Note:** JavaScript scripts cannot use `console.log()` - logging is handled by the Go worker process.
+
+## Example: Complete Worker Script
+
+```javascript
+// worker.js - Complete example
+(function() {
+  var task = $.task;
+  var input = task.inputData;
+
+  // Helper functions
+  function transformData(data) {
+    return { transformed: true, data: data.toUpperCase() };
+  }
+
+  function validateData(data) {
+    var isValid = data && data.length > 0;
+    return { valid: isValid };
+  }
+
+  function enrichData(data) {
+    return {
+      original: data,
+      enriched: {
+        timestamp: Date.now(),
+        processed: true
+      }
+    };
+  }
+
+  // Validate input
+  if (!input.action || !input.data) {
+    return {
+      status: "FAILED",
+      body: {
+        error: "Missing required fields: action, data",
+        received: input
+      }
+    };
+  }
+
+  // Process based on action
+  try {
+    var result;
+
+    switch (input.action) {
+      case "transform":
+        result = transformData(input.data);
+        break;
+      case "validate":
+        result = validateData(input.data);
+        break;
+      case "enrich":
+        result = enrichData(input.data);
+        break;
+      default:
+        return {
+          status: "FAILED",
+          body: { error: "Unknown action: " + input.action }
+        };
+    }
+
+    return {
+      status: "COMPLETED",
+      body: {
+        action: input.action,
+        result: result,
+        taskId: task.taskId,
+        workflowId: task.workflowInstanceId,
+        processedAt: new Date().toISOString()
+      }
+    };
+
+  } catch (error) {
+    return {
+      status: "FAILED",
+      body: {
+        error: error.message,
+        action: input.action,
+        taskId: task.taskId
+      }
+    };
+  }
+})();
+```

--- a/CLI_JS_WORKER_CAPABILITIES.md
+++ b/CLI_JS_WORKER_CAPABILITIES.md
@@ -1,0 +1,426 @@
+# JavaScript Worker Capabilities and Dependencies
+
+⚠️ **EXPERIMENTAL FEATURE** - This feature is experimental and may change in future releases.
+
+## Current Implementation
+
+The JavaScript worker uses **Goja**, a pure Go implementation of ECMAScript 5.1+. This provides excellent performance and security, but has different capabilities compared to Node.js.
+
+## What You Can Do
+
+### ✅ Available Features
+
+#### 1. Standard JavaScript (ES5+)
+- Variables, functions, objects, arrays
+- String manipulation
+- Number operations
+- Boolean logic
+- Regular expressions
+- Date and time operations
+- JSON parsing and stringification
+- Control flow (if/else, loops, switch, try/catch)
+- Array methods (map, filter, reduce, forEach, etc.)
+- Object methods
+
+```javascript
+// All standard JavaScript works
+const data = $.task.inputData;
+const result = data.items
+  .filter(item => item.price > 100)
+  .map(item => ({ ...item, discount: item.price * 0.1 }));
+```
+
+#### 2. Built-in Utilities
+
+The worker provides several utility namespaces with Go-powered functions:
+
+##### HTTP Requests (`http`)
+```javascript
+// GET request
+const response = http.get("https://api.example.com/data", {
+  "Authorization": "Bearer token123",
+  "Content-Type": "application/json"
+});
+
+if (response.error) {
+  console.log("HTTP error:", response.error);
+} else {
+  console.log("Status:", response.status);
+  console.log("Body:", response.body);  // Parsed JSON
+  console.log("Text:", response.text);  // Raw text
+}
+
+// POST request
+const postResponse = http.post(
+  "https://api.example.com/create",
+  { "Content-Type": "application/json" },
+  JSON.stringify({ name: "test", value: 123 })
+);
+
+// PUT request
+const putResponse = http.put(
+  "https://api.example.com/update/123",
+  { "Authorization": "Bearer token" },
+  JSON.stringify({ status: "active" })
+);
+
+// DELETE request
+const deleteResponse = http.delete(
+  "https://api.example.com/delete/123",
+  { "Authorization": "Bearer token" }
+);
+```
+
+##### Cryptographic Functions (`crypto`)
+```javascript
+// Hash functions
+const md5Hash = crypto.md5("hello world");
+const sha1Hash = crypto.sha1("hello world");
+const sha256Hash = crypto.sha256("hello world");
+
+// Base64 encoding/decoding
+const encoded = crypto.base64Encode("Hello World");
+const decoded = crypto.base64Decode(encoded);
+
+// Example: Generate API signature
+const apiKey = "my-secret-key";
+const timestamp = Date.now();
+const signature = crypto.sha256(apiKey + timestamp);
+```
+
+##### Utility Functions (`util`)
+```javascript
+// Sleep/delay execution
+util.sleep(1000); // Sleep for 1 second (1000ms)
+
+// Generate unique ID
+const uniqueId = util.uuid();
+
+// Access environment variables
+const apiKey = util.env("API_KEY");
+const dbHost = util.env("DATABASE_HOST");
+```
+
+##### String Utilities (`str`)
+```javascript
+// String manipulation
+const upper = str.toUpper("hello");        // "HELLO"
+const lower = str.toLower("WORLD");        // "world"
+const trimmed = str.trim("  spaces  ");    // "spaces"
+
+// String operations
+const parts = str.split("a,b,c", ",");     // ["a", "b", "c"]
+const joined = str.join(["a", "b"], "-");  // "a-b"
+const replaced = str.replace("hello world", "world", "goja"); // "hello goja"
+
+// String testing
+const hasIt = str.contains("hello world", "world");    // true
+const starts = str.hasPrefix("hello", "hel");          // true
+const ends = str.hasSuffix("world", "ld");             // true
+```
+
+#### 3. Access to Task Data
+```javascript
+// Full access to task information
+const taskId = $.task.taskId;
+const workflowId = $.task.workflowInstanceId;
+const input = $.task.inputData;
+const retryCount = $.task.retryCount;
+```
+
+#### 4. Console Logging
+```javascript
+console.log("Processing task:", $.task.taskId);
+console.error("Error occurred");
+```
+
+### ❌ NOT Available
+
+#### Node.js APIs
+- No `require()` or `import`
+- No `fs` (filesystem) module
+- No `process` module
+- No `Buffer` class
+- No Node.js built-in modules
+
+#### NPM Packages
+- Cannot install or use npm packages directly
+- No package.json support
+- No node_modules
+
+#### Modern JavaScript Features
+- No async/await (ES2017)
+- No Promises (limited support)
+- No ES6 modules (import/export)
+- No arrow functions in some contexts
+
+#### System Access
+- No direct file system access
+- No subprocess execution
+- No network sockets (except via http utilities)
+
+## How to Add Dependencies
+
+### Option 1: Use Built-in Utilities (Recommended)
+
+The worker provides HTTP, crypto, and string utilities. Use these for most needs:
+
+```javascript
+(function() {
+  // Instead of axios or fetch
+  var response = http.get("https://api.example.com/data", {
+    "Authorization": "Bearer " + util.env("API_TOKEN")
+  });
+
+  // Instead of crypto library
+  var hash = crypto.sha256(JSON.stringify($.task.inputData));
+
+  // Instead of lodash string functions
+  var cleanedData = str.trim(str.toLower(input.username));
+
+  // ... rest of your code
+})();
+```
+
+### Option 2: Inline JavaScript Libraries
+
+Copy small JavaScript libraries directly into your worker file:
+
+```javascript
+// worker.js
+// Include a small library inline
+function uuid() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+    var r = Math.random() * 16 | 0;
+    var v = c == 'x' ? r : (r & 0x3 | 0x8);
+    return v.toString(16);
+  });
+}
+
+// Use it
+const id = uuid();
+console.log("Generated ID:", id);
+
+// Your task processing logic
+const input = $.task.inputData;
+// ...
+```
+
+### Option 3: External API Calls
+
+Delegate complex logic to external services:
+
+```javascript
+(function() {
+  // Call your own API that has full library support
+  var response = http.post(
+    "https://your-api.com/process-task",
+    { "Content-Type": "application/json" },
+    JSON.stringify($.task.inputData)
+  );
+
+  if (response.status === 200) {
+    return {
+      status: "COMPLETED",
+      body: response.body
+    };
+  } else {
+    return {
+      status: "FAILED",
+      body: { error: "API call failed" }
+    };
+  }
+})();
+```
+
+### Option 4: Pre-process Data in Go
+
+If you need heavy dependencies, you can:
+
+1. Create a custom build of the worker with additional Go functions injected
+2. Add your own utility functions in `injectUtilities()` in `cmd/worker.go`
+3. Rebuild the CLI
+
+Example - Adding a custom function:
+
+```go
+// In cmd/worker.go, add to injectUtilities()
+vm.Set("myCustomFunction", func(data string) string {
+    // Your Go code here using any Go library
+    // Example: use a JSON schema validator, XML parser, etc.
+    return processedData
+})
+```
+
+Then use in JavaScript:
+```javascript
+const result = myCustomFunction($.task.inputData.xmlData);
+```
+
+### Option 5: Multiple Script Files (Workaround)
+
+Load common code into your worker file:
+
+```javascript
+// common.js - Your library code
+function helpers() {
+  return {
+    validateEmail: function(email) {
+      return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+    },
+    formatDate: function(timestamp) {
+      return new Date(timestamp).toISOString();
+    }
+  };
+}
+
+// worker.js - Copy common.js content at the top
+function helpers() { /* ... */ }
+
+// Use it
+const h = helpers();
+const isValid = h.validateEmail($.task.inputData.email);
+```
+
+## Complete Example: Real-World Worker
+
+```javascript
+// worker.js - Order processing with HTTP and crypto
+
+// Get task data
+const task = $.task;
+const input = task.inputData;
+
+console.log("Processing order:", input.orderId);
+
+// Validate input
+if (!input.orderId || !input.customerId) {
+  return {
+    status: "FAILED",
+    body: { error: "Missing required fields" }
+  };
+}
+
+// Generate idempotency key
+const idempotencyKey = crypto.sha256(
+  input.orderId + "-" + task.workflowInstanceId
+);
+
+// Fetch customer data
+const customerResponse = http.get(
+  "https://api.customers.com/customers/" + input.customerId,
+  {
+    "Authorization": "Bearer " + util.env("CUSTOMER_API_KEY"),
+    "X-Idempotency-Key": idempotencyKey
+  }
+);
+
+if (customerResponse.error) {
+  console.error("Failed to fetch customer:", customerResponse.error);
+  return {
+    status: "FAILED",
+    body: { error: "Customer API unavailable" }
+  };
+}
+
+const customer = customerResponse.body;
+
+// Calculate order total
+const total = input.items.reduce(function(sum, item) {
+  return sum + (item.price * item.quantity);
+}, 0);
+
+// Apply customer discount
+const discount = customer.discountPercent || 0;
+const finalTotal = total * (1 - discount / 100);
+
+// Create order in payment system
+const paymentResponse = http.post(
+  "https://api.payments.com/orders",
+  {
+    "Authorization": "Bearer " + util.env("PAYMENT_API_KEY"),
+    "Content-Type": "application/json",
+    "X-Idempotency-Key": idempotencyKey
+  },
+  JSON.stringify({
+    orderId: input.orderId,
+    customerId: input.customerId,
+    amount: finalTotal,
+    currency: "USD"
+  })
+);
+
+if (paymentResponse.error || paymentResponse.status !== 201) {
+  console.error("Payment creation failed");
+  return {
+    status: "FAILED",
+    body: {
+      error: "Payment processing failed",
+      details: paymentResponse.error || paymentResponse.text
+    }
+  };
+}
+
+// Success
+console.log("Order processed successfully:", input.orderId);
+
+return {
+  status: "COMPLETED",
+  body: {
+    orderId: input.orderId,
+    customerId: input.customerId,
+    total: finalTotal,
+    discount: discount,
+    paymentId: paymentResponse.body.paymentId,
+    processedAt: new Date().toISOString(),
+    idempotencyKey: idempotencyKey
+  }
+};
+```
+
+## Adding More Utilities
+
+If you need additional utilities, you can extend the worker by:
+
+1. **Editing `cmd/worker.go`**
+2. **Adding functions to `injectUtilities()`**
+3. **Rebuilding the CLI**
+
+Example - Add XML parsing:
+```go
+// In cmd/worker.go
+import "encoding/xml"
+
+// In injectUtilities()
+vm.Set("parseXML", func(xmlStr string) map[string]interface{} {
+    var result map[string]interface{}
+    err := xml.Unmarshal([]byte(xmlStr), &result)
+    if err != nil {
+        return map[string]interface{}{"error": err.Error()}
+    }
+    return result
+})
+```
+
+Then use in JavaScript:
+```javascript
+const xmlData = $.task.inputData.xmlString;
+const parsed = parseXML(xmlData);
+if (parsed.error) {
+  console.error("XML parsing failed:", parsed.error);
+}
+```
+
+## Summary
+
+| Need | Solution |
+|------|----------|
+| HTTP calls | Use built-in `http` object |
+| Hashing/encoding | Use built-in `crypto` object |
+| String manipulation | Use built-in `str` object |
+| Environment variables | Use `util.env()` |
+| Small utilities | Include JavaScript code inline |
+| Complex libraries | Call external APIs via `http` |
+| Custom Go functions | Modify `injectUtilities()` and rebuild |
+
+The JavaScript worker is designed for lightweight task processing with HTTP integration. For heavy processing or complex dependencies, consider calling external services that have full library support.

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -1,0 +1,374 @@
+package cmd
+
+import (
+	"context"
+	"crypto/md5"
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/antihax/optional"
+	"github.com/conductor-sdk/conductor-go/sdk/client"
+	"github.com/conductor-sdk/conductor-go/sdk/model"
+	"github.com/dop251/goja"
+	"github.com/orkes-io/conductor-cli/internal"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	workerCmd = &cobra.Command{
+		Use:   "worker",
+		Short: "Worker commands (EXPERIMENTAL)",
+		Long:  "⚠️  EXPERIMENTAL FEATURE - Worker features are experimental and may change in future releases.\n\nManage and run workers for task processing.",
+	}
+
+	workerRunCmd = &cobra.Command{
+		Use:          "run <js_file>",
+		Short:        "Run a JavaScript worker that polls and processes tasks",
+		Long:         "Run a JavaScript worker that continuously polls for tasks of a specific type and executes the provided JavaScript file for each task.",
+		RunE:         runWorker,
+		SilenceUsage: true,
+		Example:      "orkes worker run --type my_task worker.js",
+	}
+)
+
+type TaskResult struct {
+	Status string                 `json:"status"`
+	Body   map[string]interface{} `json:"body"`
+}
+
+func runWorker(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("JavaScript file path is required")
+	}
+
+	jsFile := args[0]
+	taskType, _ := cmd.Flags().GetString("type")
+	if taskType == "" {
+		return fmt.Errorf("--type flag is required")
+	}
+
+	count, _ := cmd.Flags().GetInt32("count")
+	workerId, _ := cmd.Flags().GetString("worker-id")
+	domain, _ := cmd.Flags().GetString("domain")
+	timeout, _ := cmd.Flags().GetInt32("timeout")
+
+	// Read JavaScript file
+	scriptContent, err := os.ReadFile(jsFile)
+	if err != nil {
+		return fmt.Errorf("error reading JavaScript file: %v", err)
+	}
+
+	fmt.Printf("Starting worker for task type: %s\n", taskType)
+	fmt.Printf("JavaScript file: %s\n", jsFile)
+	fmt.Printf("Worker ID: %s\n", workerId)
+
+	// Continuous polling loop
+	for {
+		opts := &client.TaskResourceApiBatchPollOpts{}
+		if workerId != "" {
+			opts.Workerid = optional.NewString(workerId)
+		}
+		if domain != "" {
+			opts.Domain = optional.NewString(domain)
+		}
+		if count > 0 {
+			opts.Count = optional.NewInt32(count)
+		}
+		if timeout > 0 {
+			opts.Timeout = optional.NewInt32(timeout)
+		}
+
+		taskClient := internal.GetTaskClient()
+		tasks, _, err := taskClient.BatchPoll(context.Background(), taskType, opts)
+		if err != nil {
+			log.Errorf("Error polling tasks: %v", err)
+			continue
+		}
+
+		if len(tasks) == 0 {
+			log.Debug("No tasks available")
+			continue
+		}
+
+		log.Infof("Polled %d task(s)", len(tasks))
+
+		// Process tasks in goroutines
+		var wg sync.WaitGroup
+		for _, task := range tasks {
+			wg.Add(1)
+			go func(t model.Task) {
+				defer wg.Done()
+				processTask(t, string(scriptContent), taskClient)
+			}(task)
+		}
+
+		wg.Wait()
+	}
+}
+
+func processTask(task model.Task, script string, taskClient *client.TaskResourceApiService) {
+	log.Infof("Processing task: %s (workflow: %s)", task.TaskId, task.WorkflowInstanceId)
+
+	// Create Goja VM
+	vm := goja.New()
+
+	// Inject task into $ global object
+	taskJSON, err := json.Marshal(task)
+	if err != nil {
+		log.Errorf("Error marshaling task: %v", err)
+		updateTaskFailed(taskClient, task, fmt.Sprintf("Error marshaling task: %v", err))
+		return
+	}
+
+	var taskObj interface{}
+	err = json.Unmarshal(taskJSON, &taskObj)
+	if err != nil {
+		log.Errorf("Error unmarshaling task: %v", err)
+		updateTaskFailed(taskClient, task, fmt.Sprintf("Error unmarshaling task: %v", err))
+		return
+	}
+
+	// Set up $ object with task
+	dollarObj := vm.NewObject()
+	err = dollarObj.Set("task", taskObj)
+	if err != nil {
+		log.Errorf("Error setting task in $: %v", err)
+		updateTaskFailed(taskClient, task, fmt.Sprintf("Error setting task: %v", err))
+		return
+	}
+	err = vm.Set("$", dollarObj)
+	if err != nil {
+		log.Errorf("Error setting $ object: %v", err)
+		updateTaskFailed(taskClient, task, fmt.Sprintf("Error setting $ object: %v", err))
+		return
+	}
+
+	// Inject utility functions
+	injectUtilities(vm)
+
+	// Execute script
+	result, err := vm.RunString(script)
+	if err != nil {
+		log.Errorf("Error executing script for task %s: %v", task.TaskId, err)
+		updateTaskFailed(taskClient, task, fmt.Sprintf("Script execution error: %v", err))
+		return
+	}
+
+	// Check if script returned a value
+	if result != nil && !goja.IsUndefined(result) && !goja.IsNull(result) {
+		// Try to parse the result as TaskResult
+		resultJSON := result.Export()
+		resultBytes, err := json.Marshal(resultJSON)
+		if err != nil {
+			log.Errorf("Error marshaling script result: %v", err)
+			updateTaskCompleted(taskClient, task, map[string]interface{}{})
+			return
+		}
+
+		var taskResult TaskResult
+		err = json.Unmarshal(resultBytes, &taskResult)
+		if err != nil {
+			// Result is not in expected format, treat as completed with raw result
+			log.Warnf("Script result not in expected format, treating as completed")
+			updateTaskCompleted(taskClient, task, map[string]interface{}{"result": resultJSON})
+			return
+		}
+
+		// Update task with returned status and body
+		if taskResult.Body == nil {
+			taskResult.Body = make(map[string]interface{})
+		}
+		updateTaskWithStatus(taskClient, task, taskResult.Status, taskResult.Body)
+	} else {
+		// No return value, mark as completed
+		updateTaskCompleted(taskClient, task, map[string]interface{}{})
+	}
+}
+
+func updateTaskCompleted(taskClient *client.TaskResourceApiService, task model.Task, output map[string]interface{}) {
+	updateTaskWithStatus(taskClient, task, "COMPLETED", output)
+}
+
+func updateTaskFailed(taskClient *client.TaskResourceApiService, task model.Task, reason string) {
+	output := map[string]interface{}{
+		"error": reason,
+	}
+	updateTaskWithStatus(taskClient, task, "FAILED", output)
+}
+
+func updateTaskWithStatus(taskClient *client.TaskResourceApiService, task model.Task, status string, output map[string]interface{}) {
+	log.Infof("Updating task %s with status: %s", task.TaskId, status)
+
+	taskResult := &model.TaskResult{
+		TaskId:             task.TaskId,
+		WorkflowInstanceId: task.WorkflowInstanceId,
+		WorkerId:           task.WorkerId,
+		Status:             model.TaskResultStatus(status),
+		OutputData:         output,
+	}
+
+	_, _, err := taskClient.UpdateTask(context.Background(), taskResult)
+	if err != nil {
+		log.Errorf("Error updating task %s: %v", task.TaskId, err)
+		return
+	}
+
+	log.Infof("Task %s updated successfully with status: %s", task.TaskId, status)
+}
+
+// injectUtilities adds utility functions to the JavaScript VM
+func injectUtilities(vm *goja.Runtime) {
+	// HTTP utilities
+	httpObj := vm.NewObject()
+	httpObj.Set("get", func(url string, headers map[string]interface{}) map[string]interface{} {
+		return httpRequest("GET", url, headers, "")
+	})
+	httpObj.Set("post", func(url string, headers map[string]interface{}, body string) map[string]interface{} {
+		return httpRequest("POST", url, headers, body)
+	})
+	httpObj.Set("put", func(url string, headers map[string]interface{}, body string) map[string]interface{} {
+		return httpRequest("PUT", url, headers, body)
+	})
+	httpObj.Set("delete", func(url string, headers map[string]interface{}) map[string]interface{} {
+		return httpRequest("DELETE", url, headers, "")
+	})
+	vm.Set("http", httpObj)
+
+	// Crypto utilities
+	cryptoObj := vm.NewObject()
+	cryptoObj.Set("md5", func(text string) string {
+		hash := md5.Sum([]byte(text))
+		return hex.EncodeToString(hash[:])
+	})
+	cryptoObj.Set("sha1", func(text string) string {
+		hash := sha1.Sum([]byte(text))
+		return hex.EncodeToString(hash[:])
+	})
+	cryptoObj.Set("sha256", func(text string) string {
+		hash := sha256.Sum256([]byte(text))
+		return hex.EncodeToString(hash[:])
+	})
+	cryptoObj.Set("base64Encode", func(text string) string {
+		return base64.StdEncoding.EncodeToString([]byte(text))
+	})
+	cryptoObj.Set("base64Decode", func(text string) string {
+		decoded, err := base64.StdEncoding.DecodeString(text)
+		if err != nil {
+			return ""
+		}
+		return string(decoded)
+	})
+	vm.Set("crypto", cryptoObj)
+
+	// Utility functions
+	utilObj := vm.NewObject()
+	utilObj.Set("sleep", func(ms int) {
+		time.Sleep(time.Duration(ms) * time.Millisecond)
+	})
+	utilObj.Set("uuid", func() string {
+		return fmt.Sprintf("%d-%d", time.Now().UnixNano(), os.Getpid())
+	})
+	utilObj.Set("env", func(key string) string {
+		return os.Getenv(key)
+	})
+	vm.Set("util", utilObj)
+
+	// String utilities
+	stringObj := vm.NewObject()
+	stringObj.Set("toUpper", strings.ToUpper)
+	stringObj.Set("toLower", strings.ToLower)
+	stringObj.Set("trim", strings.TrimSpace)
+	stringObj.Set("split", func(s, sep string) []string {
+		return strings.Split(s, sep)
+	})
+	stringObj.Set("join", func(arr []string, sep string) string {
+		return strings.Join(arr, sep)
+	})
+	stringObj.Set("replace", func(s, old, new string) string {
+		return strings.ReplaceAll(s, old, new)
+	})
+	stringObj.Set("contains", strings.Contains)
+	stringObj.Set("hasPrefix", strings.HasPrefix)
+	stringObj.Set("hasSuffix", strings.HasSuffix)
+	vm.Set("str", stringObj)
+}
+
+// httpRequest performs HTTP requests from JavaScript
+func httpRequest(method, url string, headers map[string]interface{}, body string) map[string]interface{} {
+	var bodyReader io.Reader
+	if body != "" {
+		bodyReader = strings.NewReader(body)
+	}
+
+	req, err := http.NewRequest(method, url, bodyReader)
+	if err != nil {
+		return map[string]interface{}{
+			"error":  err.Error(),
+			"status": 0,
+		}
+	}
+
+	// Set headers
+	for key, value := range headers {
+		if strVal, ok := value.(string); ok {
+			req.Header.Set(key, strVal)
+		}
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return map[string]interface{}{
+			"error":  err.Error(),
+			"status": 0,
+		}
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return map[string]interface{}{
+			"error":  err.Error(),
+			"status": resp.StatusCode,
+		}
+	}
+
+	// Try to parse as JSON
+	var jsonBody interface{}
+	if err := json.Unmarshal(respBody, &jsonBody); err == nil {
+		return map[string]interface{}{
+			"status": resp.StatusCode,
+			"body":   jsonBody,
+			"text":   string(respBody),
+		}
+	}
+
+	// Return as text if not JSON
+	return map[string]interface{}{
+		"status": resp.StatusCode,
+		"text":   string(respBody),
+	}
+}
+
+func init() {
+	workerRunCmd.Flags().String("type", "", "Task type to poll for (required)")
+	workerRunCmd.MarkFlagRequired("type")
+	workerRunCmd.Flags().Int32("count", 1, "Number of tasks to poll in each batch")
+	workerRunCmd.Flags().String("worker-id", "", "Worker ID")
+	workerRunCmd.Flags().String("domain", "", "Domain")
+	workerRunCmd.Flags().Int32("timeout", 100, "Timeout in milliseconds")
+
+	workerCmd.AddCommand(workerRunCmd)
+	rootCmd.AddCommand(workerCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23
 require (
 	github.com/antihax/optional v1.0.0
 	github.com/conductor-sdk/conductor-go v1.6.0
-	github.com/dop251/goja v0.0.0-20230402114112-623f9dda9079
+	github.com/dop251/goja v0.0.0-20251008123653-cf18d89f3cf6
 	github.com/dop251/goja_nodejs v0.0.0-20230322100729-2550c7b6c124
 	github.com/google/uuid v1.4.0
 	github.com/sirupsen/logrus v1.9.3
@@ -14,7 +14,7 @@ require (
 )
 
 require (
-	github.com/dlclark/regexp2 v1.7.0 // indirect
+	github.com/dlclark/regexp2 v1.11.4 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
 	github.com/google/pprof v0.0.0-20230207041349-798e818bf904 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,10 +14,14 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dlclark/regexp2 v1.7.0 h1:7lJfhqlPssTb1WQx4yvTHN0uElPEv52sbaECrAQxjAo=
 github.com/dlclark/regexp2 v1.7.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/dlclark/regexp2 v1.11.4 h1:rPYF9/LECdNymJufQKmri9gV604RvvABwgOA8un7yAo=
+github.com/dlclark/regexp2 v1.11.4/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dop251/goja v0.0.0-20211022113120-dc8c55024d06/go.mod h1:R9ET47fwRVRPZnOGvHxxhuZcbrMCuiqOz3Rlrh4KSnk=
 github.com/dop251/goja v0.0.0-20221118162653-d4bf6fde1b86/go.mod h1:yRkwfj0CBpOGre+TwBsqPV0IH0Pk73e4PXJOeNDboGs=
 github.com/dop251/goja v0.0.0-20230402114112-623f9dda9079 h1:xkbJGxVnk5sM8/LXeTKaBOfAZrI+iqvIPyH8oK1c6CQ=
 github.com/dop251/goja v0.0.0-20230402114112-623f9dda9079/go.mod h1:QMWlm50DNe14hD7t24KEqZuUdC9sOTy8W6XbCU1mlw4=
+github.com/dop251/goja v0.0.0-20251008123653-cf18d89f3cf6 h1:6dE1TmjqkY6tehR4A67gDNhvDtuZ54ocu7ab4K9o540=
+github.com/dop251/goja v0.0.0-20251008123653-cf18d89f3cf6/go.mod h1:MxLav0peU43GgvwVgNbLAj1s/bSGboKkhuULvq/7hx4=
 github.com/dop251/goja_nodejs v0.0.0-20210225215109-d91c329300e7/go.mod h1:hn7BA7c8pLvoGndExHudxTDKZ84Pyvv+90pbBjbTz0Y=
 github.com/dop251/goja_nodejs v0.0.0-20211022123610-8dd9abb0616d/go.mod h1:DngW8aVqWbuLRMHItjPUyqdj+HWPvnQe8V8y1nDpIbM=
 github.com/dop251/goja_nodejs v0.0.0-20230322100729-2550c7b6c124 h1:QDuDMgEkC/lnmvk0d/fZfcUUml18uUbS9TY5QtbdFhs=


### PR DESCRIPTION
## Experimental

Added support for running JS workers with the CLI. E.g.:

```bash
orkes worker run --type cli_worker worker.js
```

worker.js
```js
(function() {
    var response = http.get("https://catfact.ninja/fact", {});
    if (response.error) {
        return {
            status: "FAILED",
            body: { error: "Failed to fetch cat fact: " + response.error }
        };
    }

    if (response.status !== 200) {
        return {
            status: "FAILED",
            body: { error: "HTTP error: " + response.status }
        };
    }

    var catFact = response.body.fact;
    return {
        status: "COMPLETED",
        body: {
            fact: catFact,
            taskId: $.task.taskId,
            fetchedAt: new Date().toISOString()
        }
    };
})();
```

With this feature users can run lightweight workers just with the CLI.

<img width="932" height="313" alt="Screenshot 2025-10-17 at 15 38 40" src="https://github.com/user-attachments/assets/693c04ef-e8df-410a-8680-ca23849aa077" />

