### PR TITLE
Silence global flags in subcommands when showing usage

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -240,6 +240,16 @@ func init() {
 		defaultHelpFunc(cmd, args)
 	})
 
+	defaultUsageFunc := rootCmd.UsageFunc()
+	rootCmd.SetUsageFunc(func(cmd *cobra.Command) error {
+		if cmd.HasParent() {
+			cmd.InheritedFlags().VisitAll(func(flag *pflag.Flag) {
+				flag.Hidden = true
+			})
+		}
+		return defaultUsageFunc(cmd)
+	})
+
 	// Configuration file flag
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.conductor-cli/config.yaml)")
 


### PR DESCRIPTION
Silence global flags in subcommands when showing usage (still visible in the root command)

This is too noisy

<img width="600"  src="https://github.com/user-attachments/assets/0e11163d-1e03-427d-8746-ab5fb9fc1c33" />


This seems better 
<img width="699" src="https://github.com/user-attachments/assets/52e9fc0c-9f9c-4884-8726-a46452c35e32" />

