### PR TITLE
Secret management support

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,7 +49,7 @@ jobs:
         CONDUCTOR_AUTH_SECRET: ${{ secrets.CONDUCTOR_AUTH_SECRET }}
         CONDUCTOR_SERVER_TYPE: Enterprise
       run: |
-        bats test/e2e/workflow.bats test/e2e/rerun.bats test/e2e/schedule.bats test/e2e/webhook.bats test/e2e/whoami.bats --show-output-of-passing-tests
+        bats test/e2e/workflow.bats test/e2e/rerun.bats test/e2e/schedule.bats test/e2e/webhook.bats test/e2e/secret.bats test/e2e/whoami.bats --show-output-of-passing-tests
 
     - name: Upload test artifacts
       if: always()

--- a/cmd/secret.go
+++ b/cmd/secret.go
@@ -1,0 +1,543 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/conductor-sdk/conductor-go/sdk/model"
+	"github.com/orkes-io/conductor-cli/internal"
+	"github.com/spf13/cobra"
+)
+
+var secretCmd = &cobra.Command{
+	Use:     "secret",
+	Short:   "Secret management",
+	GroupID: "conductor",
+}
+
+var (
+	listSecretsCmd = &cobra.Command{
+		Use:          "list",
+		Short:        "List all secrets",
+		RunE:         listSecrets,
+		SilenceUsage: true,
+		Example:      "secret list --with-tags",
+	}
+
+	getSecretCmd = &cobra.Command{
+		Use:          "get <key>",
+		Short:        "Get secret value",
+		RunE:         getSecret,
+		SilenceUsage: true,
+		Example:      "secret get db_password --show-value",
+	}
+
+	putSecretCmd = &cobra.Command{
+		Use:          "put <key> [value]",
+		Short:        "Create or update a secret",
+		Long:         "Create or update a secret. Value can be provided as argument, via --value flag, or from stdin",
+		RunE:         putSecret,
+		SilenceUsage: true,
+		Example: `  # Put secret with value as argument
+  orkes secret put db_password mySecretValue
+
+  # Put secret with value from flag
+  orkes secret put db_password --value mySecretValue
+
+  # Put secret from stdin
+  echo "mySecretValue" | orkes secret put db_password
+
+  # Put secret from file
+  cat secret.txt | orkes secret put db_password`,
+	}
+
+	deleteSecretCmd = &cobra.Command{
+		Use:          "delete <key>",
+		Short:        "Delete a secret",
+		RunE:         deleteSecret,
+		SilenceUsage: true,
+		Example:      "secret delete db_password",
+	}
+
+	existsSecretCmd = &cobra.Command{
+		Use:          "exists <key>",
+		Short:        "Check if a secret exists",
+		RunE:         existsSecret,
+		SilenceUsage: true,
+		Example:      "secret exists db_password",
+	}
+
+	tagListCmd = &cobra.Command{
+		Use:          "tag-list <key>",
+		Short:        "List tags for a secret",
+		RunE:         tagList,
+		SilenceUsage: true,
+		Example:      "secret tag-list db_password",
+	}
+
+	tagAddCmd = &cobra.Command{
+		Use:          "tag-add <key>",
+		Short:        "Add tags to a secret",
+		RunE:         tagAdd,
+		SilenceUsage: true,
+		Example: `  # Add single tag
+  orkes secret tag-add db_password --tag env:prod
+
+  # Add multiple tags
+  orkes secret tag-add db_password --tag env:prod --tag team:backend`,
+	}
+
+	tagDeleteCmd = &cobra.Command{
+		Use:          "tag-delete <key>",
+		Short:        "Delete tags from a secret",
+		RunE:         tagDelete,
+		SilenceUsage: true,
+		Example: `  # Delete single tag
+  orkes secret tag-delete db_password --tag env:prod
+
+  # Delete multiple tags
+  orkes secret tag-delete db_password --tag env:prod --tag team:backend`,
+	}
+
+	cacheClearCmd = &cobra.Command{
+		Use:          "cache-clear",
+		Short:        "Clear secrets cache",
+		Long:         "Clear secrets cache. Use --local or --redis flags to specify which cache to clear. If neither flag is provided, both caches will be cleared.",
+		RunE:         cacheClear,
+		SilenceUsage: true,
+		Example: `  # Clear local cache
+  orkes secret cache-clear --local
+
+  # Clear Redis cache
+  orkes secret cache-clear --redis
+
+  # Clear both caches
+  orkes secret cache-clear`,
+	}
+)
+
+func listSecrets(cmd *cobra.Command, args []string) error {
+	if !isEnterpriseServer() {
+		return fmt.Errorf("Not supported in OSS Conductor")
+	}
+
+	secretClient := internal.GetSecretsClient()
+	withTags, _ := cmd.Flags().GetBool("with-tags")
+	jsonOutput, _ := cmd.Flags().GetBool("json")
+
+	ctx := context.Background()
+
+	if withTags {
+		// List secrets with tags
+		secrets, _, err := secretClient.ListSecretsWithTagsThatUserCanGrantAccessTo(ctx)
+		if err != nil {
+			return parseAPIError(err, "Failed to list secrets")
+		}
+
+		if jsonOutput {
+			data, err := json.MarshalIndent(secrets, "", "  ")
+			if err != nil {
+				return fmt.Errorf("error marshaling secrets: %v", err)
+			}
+			fmt.Println(string(data))
+			return nil
+		}
+
+		// Print as table
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		fmt.Fprintln(w, "KEY\tTAGS")
+		for _, secret := range secrets {
+			tagStr := "-"
+			if len(secret.Tags) > 0 {
+				tagPairs := make([]string, 0, len(secret.Tags))
+				for _, tag := range secret.Tags {
+					tagPairs = append(tagPairs, fmt.Sprintf("%s:%s", tag.Key, tag.Value))
+				}
+				tagStr = strings.Join(tagPairs, ", ")
+				if len(tagStr) > 50 {
+					tagStr = tagStr[:47] + "..."
+				}
+			}
+			fmt.Fprintf(w, "%s\t%s\n", secret.Name, tagStr)
+		}
+		w.Flush()
+	} else {
+		// List secret names only
+		secretNames, _, err := secretClient.ListAllSecretNames(ctx)
+		if err != nil {
+			return parseAPIError(err, "Failed to list secrets")
+		}
+
+		if jsonOutput {
+			data, err := json.MarshalIndent(secretNames, "", "  ")
+			if err != nil {
+				return fmt.Errorf("error marshaling secrets: %v", err)
+			}
+			fmt.Println(string(data))
+			return nil
+		}
+
+		// Print as simple list
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		fmt.Fprintln(w, "KEY")
+		for _, name := range secretNames {
+			fmt.Fprintln(w, name)
+		}
+		w.Flush()
+	}
+
+	return nil
+}
+
+func getSecret(cmd *cobra.Command, args []string) error {
+	if !isEnterpriseServer() {
+		return fmt.Errorf("Not supported in OSS Conductor")
+	}
+
+	if len(args) == 0 {
+		return cmd.Usage()
+	}
+
+	key := args[0]
+	showValue, _ := cmd.Flags().GetBool("show-value")
+	secretClient := internal.GetSecretsClient()
+
+	ctx := context.Background()
+	value, _, err := secretClient.GetSecret(ctx, key)
+	if err != nil {
+		return parseAPIError(err, fmt.Sprintf("Failed to get secret '%s'", key))
+	}
+
+	if showValue {
+		fmt.Println(value)
+	} else {
+		fmt.Println("Secret exists. Use --show-value to display the actual value.")
+	}
+
+	return nil
+}
+
+func putSecret(cmd *cobra.Command, args []string) error {
+	if !isEnterpriseServer() {
+		return fmt.Errorf("Not supported in OSS Conductor")
+	}
+
+	if len(args) == 0 {
+		return cmd.Usage()
+	}
+
+	key := args[0]
+	var value string
+
+	// Get value from flag first
+	flagValue, _ := cmd.Flags().GetString("value")
+	if flagValue != "" {
+		value = flagValue
+	} else if len(args) > 1 {
+		// Get value from second argument
+		value = args[1]
+	} else {
+		// Check if reading from stdin (pipe)
+		stat, _ := os.Stdin.Stat()
+		if (stat.Mode() & os.ModeCharDevice) == 0 {
+			// Reading from pipe
+			data, err := os.ReadFile("/dev/stdin")
+			if err != nil {
+				return fmt.Errorf("error reading from stdin: %v", err)
+			}
+			value = strings.TrimSpace(string(data))
+		} else {
+			return fmt.Errorf("secret value required: provide as argument, --value flag, or via stdin")
+		}
+	}
+
+	if value == "" {
+		return fmt.Errorf("secret value cannot be empty")
+	}
+
+	secretClient := internal.GetSecretsClient()
+	ctx := context.Background()
+	_, _, err := secretClient.PutSecret(ctx, value, key)
+	if err != nil {
+		return parseAPIError(err, fmt.Sprintf("Failed to put secret '%s'", key))
+	}
+
+	fmt.Printf("Secret '%s' saved successfully\n", key)
+	return nil
+}
+
+func deleteSecret(cmd *cobra.Command, args []string) error {
+	if !isEnterpriseServer() {
+		return fmt.Errorf("Not supported in OSS Conductor")
+	}
+
+	if len(args) == 0 {
+		return cmd.Usage()
+	}
+
+	key := args[0]
+
+	// Confirm deletion
+	if !confirmDeletion("secret", key) {
+		fmt.Println("Deletion cancelled")
+		return nil
+	}
+
+	secretClient := internal.GetSecretsClient()
+	ctx := context.Background()
+	_, _, err := secretClient.DeleteSecret(ctx, key)
+	if err != nil {
+		return parseAPIError(err, fmt.Sprintf("Failed to delete secret '%s'", key))
+	}
+
+	fmt.Printf("Secret '%s' deleted successfully\n", key)
+	return nil
+}
+
+func existsSecret(cmd *cobra.Command, args []string) error {
+	if !isEnterpriseServer() {
+		return fmt.Errorf("Not supported in OSS Conductor")
+	}
+
+	if len(args) == 0 {
+		return cmd.Usage()
+	}
+
+	key := args[0]
+	secretClient := internal.GetSecretsClient()
+
+	ctx := context.Background()
+	_, resp, err := secretClient.SecretExists(ctx, key)
+	if err != nil {
+		return parseAPIError(err, fmt.Sprintf("Failed to check if secret '%s' exists", key))
+	}
+
+	if resp.StatusCode == 200 {
+		fmt.Printf("Secret '%s' exists\n", key)
+	} else {
+		fmt.Printf("Secret '%s' does not exist\n", key)
+	}
+
+	return nil
+}
+
+func tagList(cmd *cobra.Command, args []string) error {
+	if !isEnterpriseServer() {
+		return fmt.Errorf("Not supported in OSS Conductor")
+	}
+
+	if len(args) == 0 {
+		return cmd.Usage()
+	}
+
+	key := args[0]
+	jsonOutput, _ := cmd.Flags().GetBool("json")
+	secretClient := internal.GetSecretsClient()
+
+	ctx := context.Background()
+	tags, _, err := secretClient.GetTags(ctx, key)
+	if err != nil {
+		return parseAPIError(err, fmt.Sprintf("Failed to get tags for secret '%s'", key))
+	}
+
+	if jsonOutput {
+		data, err := json.MarshalIndent(tags, "", "  ")
+		if err != nil {
+			return fmt.Errorf("error marshaling tags: %v", err)
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+
+	if len(tags) == 0 {
+		fmt.Println("No tags found")
+		return nil
+	}
+
+	// Print as table
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "KEY\tVALUE\tTYPE")
+	for _, tag := range tags {
+		tagType := tag.Type_
+		if tagType == "" {
+			tagType = "-"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\n", tag.Key, tag.Value, tagType)
+	}
+	w.Flush()
+
+	return nil
+}
+
+func tagAdd(cmd *cobra.Command, args []string) error {
+	if !isEnterpriseServer() {
+		return fmt.Errorf("Not supported in OSS Conductor")
+	}
+
+	if len(args) == 0 {
+		return cmd.Usage()
+	}
+
+	key := args[0]
+	tagStrings, _ := cmd.Flags().GetStringArray("tag")
+
+	if len(tagStrings) == 0 {
+		return fmt.Errorf("at least one --tag flag is required")
+	}
+
+	// Parse tags
+	tags := make([]model.Tag, 0, len(tagStrings))
+	for _, tagStr := range tagStrings {
+		parts := strings.SplitN(tagStr, ":", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid tag format '%s': expected key:value", tagStr)
+		}
+		tags = append(tags, model.Tag{
+			Key:   strings.TrimSpace(parts[0]),
+			Value: strings.TrimSpace(parts[1]),
+			Type_: "metadata",
+		})
+	}
+
+	secretClient := internal.GetSecretsClient()
+	ctx := context.Background()
+	_, err := secretClient.PutTagForSecret(ctx, tags, key)
+	if err != nil {
+		return parseAPIError(err, fmt.Sprintf("Failed to add tags to secret '%s'", key))
+	}
+
+	fmt.Printf("Tags added to secret '%s' successfully\n", key)
+	return nil
+}
+
+func tagDelete(cmd *cobra.Command, args []string) error {
+	if !isEnterpriseServer() {
+		return fmt.Errorf("Not supported in OSS Conductor")
+	}
+
+	if len(args) == 0 {
+		return cmd.Usage()
+	}
+
+	key := args[0]
+	tagStrings, _ := cmd.Flags().GetStringArray("tag")
+
+	if len(tagStrings) == 0 {
+		return fmt.Errorf("at least one --tag flag is required")
+	}
+
+	// Parse tags
+	tags := make([]model.Tag, 0, len(tagStrings))
+	for _, tagStr := range tagStrings {
+		parts := strings.SplitN(tagStr, ":", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid tag format '%s': expected key:value", tagStr)
+		}
+		tags = append(tags, model.Tag{
+			Key:   strings.TrimSpace(parts[0]),
+			Value: strings.TrimSpace(parts[1]),
+			Type_: "metadata",
+		})
+	}
+
+	secretClient := internal.GetSecretsClient()
+	ctx := context.Background()
+	_, err := secretClient.DeleteTagForSecret(ctx, tags, key)
+	if err != nil {
+		return parseAPIError(err, fmt.Sprintf("Failed to delete tags from secret '%s'", key))
+	}
+
+	fmt.Printf("Tags deleted from secret '%s' successfully\n", key)
+	return nil
+}
+
+func cacheClear(cmd *cobra.Command, args []string) error {
+	if !isEnterpriseServer() {
+		return fmt.Errorf("Not supported in OSS Conductor")
+	}
+
+	local, _ := cmd.Flags().GetBool("local")
+	redis, _ := cmd.Flags().GetBool("redis")
+
+	// If neither flag is set, clear both
+	if !local && !redis {
+		local = true
+		redis = true
+	}
+
+	secretClient := internal.GetSecretsClient()
+	ctx := context.Background()
+
+	if local {
+		result, _, err := secretClient.ClearLocalCache(ctx)
+		if err != nil {
+			return parseAPIError(err, "Failed to clear local cache")
+		}
+
+		fmt.Println("Local cache cleared successfully")
+		if len(result) > 0 {
+			data, _ := json.MarshalIndent(result, "", "  ")
+			fmt.Println(string(data))
+		}
+	}
+
+	if redis {
+		result, _, err := secretClient.ClearRedisCache(ctx)
+		if err != nil {
+			return parseAPIError(err, "Failed to clear Redis cache")
+		}
+
+		fmt.Println("Redis cache cleared successfully")
+		if len(result) > 0 {
+			data, _ := json.MarshalIndent(result, "", "  ")
+			fmt.Println(string(data))
+		}
+	}
+
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(secretCmd)
+
+	// List command flags
+	listSecretsCmd.Flags().Bool("with-tags", false, "Include tags in the output")
+	listSecretsCmd.Flags().Bool("json", false, "Output as JSON")
+
+	// Get command flags
+	getSecretCmd.Flags().Bool("show-value", false, "Display the actual secret value")
+
+	// Put command flags
+	putSecretCmd.Flags().String("value", "", "Secret value")
+
+	// Tag list command flags
+	tagListCmd.Flags().Bool("json", false, "Output as JSON")
+
+	// Tag add command flags
+	tagAddCmd.Flags().StringArray("tag", []string{}, "Tag in key:value format (repeatable)")
+	tagAddCmd.MarkFlagRequired("tag")
+
+	// Tag delete command flags
+	tagDeleteCmd.Flags().StringArray("tag", []string{}, "Tag in key:value format (repeatable)")
+	tagDeleteCmd.MarkFlagRequired("tag")
+
+	// Cache clear command flags
+	cacheClearCmd.Flags().Bool("local", false, "Clear local cache only")
+	cacheClearCmd.Flags().Bool("redis", false, "Clear Redis cache only")
+
+	secretCmd.AddCommand(
+		listSecretsCmd,
+		getSecretCmd,
+		putSecretCmd,
+		deleteSecretCmd,
+		existsSecretCmd,
+		tagListCmd,
+		tagAddCmd,
+		tagDeleteCmd,
+		cacheClearCmd,
+	)
+}

--- a/internal/settings.go
+++ b/internal/settings.go
@@ -34,6 +34,10 @@ func GetTaskClient() *client.TaskResourceApiService {
 	return &client.TaskResourceApiService{APIClient: apiClient}
 }
 
+func GetSecretsClient() client.SecretsClient {
+	return client.NewSecretsClient(apiClient)
+}
+
 func SetAPIClient(client *client.APIClient) {
 	apiClient = client
 }

--- a/test/e2e/secret.bats
+++ b/test/e2e/secret.bats
@@ -1,0 +1,247 @@
+#!/usr/bin/env bats
+
+# E2E tests for secret management functionality
+
+SECRET_KEY="e2e_test_secret"
+SECRET_KEY_2="e2e_test_secret_2"
+SECRET_VALUE="test_secret_value_12345"
+SECRET_VALUE_UPDATED="updated_secret_value_67890"
+
+setup() {
+    # Ensure the CLI binary exists
+    if [ ! -f "./orkes" ]; then
+        echo "ERROR: orkes binary not found. Please build it first."
+        exit 1
+    fi
+
+    # Clean up any existing test secrets
+    ./orkes secret delete "$SECRET_KEY" -y 2>/dev/null || true
+    ./orkes secret delete "$SECRET_KEY_2" -y 2>/dev/null || true
+}
+
+teardown() {
+    # Clean up test secrets after each test
+    ./orkes secret delete "$SECRET_KEY" -y 2>/dev/null || true
+    ./orkes secret delete "$SECRET_KEY_2" -y 2>/dev/null || true
+}
+
+@test "1. Create secret using command arguments" {
+    run bash -c "./orkes secret put '$SECRET_KEY' '$SECRET_VALUE' 2>&1"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "saved successfully"
+}
+
+@test "2. Check if secret exists" {
+    # Create secret first
+    ./orkes secret put "$SECRET_KEY" "$SECRET_VALUE" 2>/dev/null
+
+    # Check if it exists
+    run bash -c "./orkes secret exists '$SECRET_KEY' 2>&1"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "exists"
+}
+
+@test "3. Get secret value (without --show-value flag)" {
+    # Create secret first
+    ./orkes secret put "$SECRET_KEY" "$SECRET_VALUE" 2>/dev/null
+
+    # Get without showing value
+    run bash -c "./orkes secret get '$SECRET_KEY' 2>&1"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "Secret exists"
+    # Should NOT contain the actual value
+    ! echo "$output" | grep -q "$SECRET_VALUE"
+}
+
+@test "4. Get secret value (with --show-value flag)" {
+    # Create secret first
+    ./orkes secret put "$SECRET_KEY" "$SECRET_VALUE" 2>/dev/null
+
+    # Get with showing value
+    run bash -c "./orkes secret get '$SECRET_KEY' --show-value 2>&1"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    # Should contain the actual value
+    echo "$output" | grep -q "$SECRET_VALUE"
+}
+
+@test "5. Update secret with new value" {
+    # Create secret first
+    ./orkes secret put "$SECRET_KEY" "$SECRET_VALUE" 2>/dev/null
+
+    # Update with new value
+    run bash -c "./orkes secret put '$SECRET_KEY' '$SECRET_VALUE_UPDATED' 2>&1"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "saved successfully"
+
+    # Verify new value
+    run bash -c "./orkes secret get '$SECRET_KEY' --show-value 2>&1"
+    echo "$output" | grep -q "$SECRET_VALUE_UPDATED"
+    # Old value should not be present
+    ! echo "$output" | grep -q "$SECRET_VALUE"
+}
+
+@test "6. Create secret using --value flag" {
+    run bash -c "./orkes secret put '$SECRET_KEY_2' --value '$SECRET_VALUE' 2>&1"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "saved successfully"
+
+    # Verify value
+    run bash -c "./orkes secret get '$SECRET_KEY_2' --show-value 2>&1"
+    echo "$output" | grep -q "$SECRET_VALUE"
+}
+
+@test "7. Create secret from stdin" {
+    run bash -c "echo '$SECRET_VALUE' | ./orkes secret put '$SECRET_KEY' 2>&1"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "saved successfully"
+
+    # Verify value
+    run bash -c "./orkes secret get '$SECRET_KEY' --show-value 2>&1"
+    echo "$output" | grep -q "$SECRET_VALUE"
+}
+
+@test "8. List secrets (should include created secret)" {
+    # Create secret first
+    ./orkes secret put "$SECRET_KEY" "$SECRET_VALUE" 2>/dev/null
+
+    # List secrets
+    run bash -c "./orkes secret list 2>&1"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "$SECRET_KEY"
+}
+
+@test "9. List secrets with JSON output" {
+    # Create secret first
+    ./orkes secret put "$SECRET_KEY" "$SECRET_VALUE" 2>/dev/null
+
+    # List with JSON
+    run bash -c "./orkes secret list --json 2>&1"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "$SECRET_KEY"
+}
+
+@test "10. Add tags to secret" {
+    # Create secret first
+    ./orkes secret put "$SECRET_KEY" "$SECRET_VALUE" 2>/dev/null
+
+    # Add tags
+    run bash -c "./orkes secret tag-add '$SECRET_KEY' --tag env:test --tag team:e2e 2>&1"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "Tags added"
+}
+
+@test "11. List tags for secret" {
+    # Create secret and add tags
+    ./orkes secret put "$SECRET_KEY" "$SECRET_VALUE" 2>/dev/null
+    ./orkes secret tag-add "$SECRET_KEY" --tag env:test --tag team:e2e 2>/dev/null
+
+    # List tags
+    run bash -c "./orkes secret tag-list '$SECRET_KEY' 2>&1"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "env"
+    echo "$output" | grep -q "test"
+    echo "$output" | grep -q "team"
+    echo "$output" | grep -q "e2e"
+}
+
+@test "12. List secrets with tags" {
+    # Create secret and add tags
+    ./orkes secret put "$SECRET_KEY" "$SECRET_VALUE" 2>/dev/null
+    ./orkes secret tag-add "$SECRET_KEY" --tag env:test 2>/dev/null
+
+    # List with tags
+    run bash -c "./orkes secret list --with-tags 2>&1"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "$SECRET_KEY"
+    echo "$output" | grep -q "env:test"
+}
+
+@test "13. Delete tags from secret" {
+    # Create secret and add tags
+    ./orkes secret put "$SECRET_KEY" "$SECRET_VALUE" 2>/dev/null
+    ./orkes secret tag-add "$SECRET_KEY" --tag env:test --tag team:e2e 2>/dev/null
+
+    # Delete one tag
+    run bash -c "./orkes secret tag-delete '$SECRET_KEY' --tag env:test 2>&1"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "Tags deleted"
+
+    # Verify tag was deleted
+    run bash -c "./orkes secret tag-list '$SECRET_KEY' 2>&1"
+    echo "Output: $output"
+    # Should still have team tag
+    echo "$output" | grep -q "team"
+    # Should not have env tag
+    ! echo "$output" | grep -q "env.*test"
+}
+
+@test "14. Clear local cache" {
+    run bash -c "./orkes secret cache-clear --local 2>&1"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "Local cache cleared successfully"
+}
+
+@test "15. Clear Redis cache" {
+    run bash -c "./orkes secret cache-clear --redis 2>&1"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "Redis cache cleared successfully"
+}
+
+@test "16. Clear both caches (no flags)" {
+    run bash -c "./orkes secret cache-clear 2>&1"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "Local cache cleared successfully"
+    echo "$output" | grep -q "Redis cache cleared successfully"
+}
+
+@test "17. Delete secret" {
+    # Create secret first
+    ./orkes secret put "$SECRET_KEY" "$SECRET_VALUE" 2>/dev/null
+
+    # Delete with -y flag to skip confirmation
+    run bash -c "./orkes secret delete '$SECRET_KEY' -y 2>&1"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "deleted successfully"
+}
+
+@test "18. Verify deleted secret no longer exists" {
+    # Create and then delete secret
+    ./orkes secret put "$SECRET_KEY" "$SECRET_VALUE" 2>/dev/null
+    ./orkes secret delete "$SECRET_KEY" -y 2>/dev/null
+
+    # Try to get deleted secret (should fail)
+    run bash -c "./orkes secret get '$SECRET_KEY' 2>&1"
+    echo "Output: $output"
+    [ "$status" -ne 0 ]
+}
+
+@test "19. Error handling - get non-existent secret" {
+    # Try to get a secret that doesn't exist
+    run bash -c "./orkes secret get 'non_existent_secret_xyz' 2>&1"
+    echo "Output: $output"
+    [ "$status" -ne 0 ]
+}
+
+@test "20. Error handling - delete non-existent secret" {
+    # Try to delete a secret that doesn't exist
+    run bash -c "./orkes secret delete 'non_existent_secret_xyz' -y 2>&1"
+    echo "Output: $output"
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Changes in this PR

Added support for managing secrets.

i.e.:
```
$ orkes secret --help
Secret management

Usage:
  orkes secret [command]

Available Commands:
  cache-clear Clear secrets cache
  delete    Delete a secret
  exists    Check if a secret exists
  get       Get secret value
  list      List all secrets
  put       Create or update a secret
  tag-add   Add tags to a secret
  tag-delete Delete tags from a secret
  tag-list  List tags for a secret
```