### PR TITLE
`orkes code` uses `conductor-oss/cli-templates` 

### DIFF
--- a/cmd/code.go
+++ b/cmd/code.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	defaultTemplateRepo = "mp-orkes/cli-templates"
+	defaultTemplateRepo = "conductor-oss/cli-templates"
 )
 
 type TemplatesConfig struct {


### PR DESCRIPTION
# Changes in this PR

Use repo `conductor-oss/cli-templates` for code generation