### PR TITLE
Configuration of templates repo

### DIFF
--- a/cmd/code.go
+++ b/cmd/code.go
@@ -13,45 +13,18 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"gopkg.in/yaml.v3"
 )
 
 const (
-	defaultTemplateRepo = "conductor-oss/cli-templates"
+	defaultTemplateURL = "https://raw.githubusercontent.com/conductor-oss/cli-templates/main"
 )
 
-type TemplatesConfig struct {
-	Repo string `yaml:"repo"`
-}
-
-func getTemplateRepo() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return defaultTemplateRepo
-	}
-
-	configPath := filepath.Join(home, ".conductor-cli", "templates.yaml")
-	data, err := os.ReadFile(configPath)
-	if err != nil {
-		// File doesn't exist, use default
-		return defaultTemplateRepo
-	}
-
-	var config TemplatesConfig
-	if err := yaml.Unmarshal(data, &config); err != nil {
-		return defaultTemplateRepo
-	}
-
-	if config.Repo == "" {
-		return defaultTemplateRepo
-	}
-
-	return config.Repo
-}
-
 func getTemplateBaseURL() string {
-	repo := getTemplateRepo()
-	return fmt.Sprintf("https://raw.githubusercontent.com/%s/main", repo)
+	templateURL := viper.GetString("template-url")
+	if templateURL != "" {
+		return templateURL
+	}
+	return defaultTemplateURL
 }
 
 func getListURL() string {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -257,6 +257,18 @@ func interactiveSaveConfig(profileName string) error {
 		serverType = serverTypeInput
 	}
 
+	templateURLDefault := existingConfig["template-url"]
+	if templateURLDefault == "" {
+		templateURLDefault = "https://raw.githubusercontent.com/conductor-oss/cli-templates/main"
+	}
+	fmt.Fprintf(os.Stdout, "Template repo URL [%s]: ", templateURLDefault)
+	templateURLInput, _ := reader.ReadString('\n')
+	templateURLInput = strings.TrimSpace(templateURLInput)
+	templateURL := templateURLDefault
+	if templateURLInput != "" {
+		templateURL = templateURLInput
+	}
+
 	// Prompt for auth method
 	fmt.Fprintf(os.Stdout, "\nAuthentication method:\n")
 	fmt.Fprintf(os.Stdout, "  1. API Key + Secret\n")
@@ -326,6 +338,7 @@ func interactiveSaveConfig(profileName string) error {
 	configData := make(map[string]interface{})
 	configData["server"] = server
 	configData["server-type"] = serverType
+	configData["template-url"] = templateURL
 
 	if authKey != "" {
 		configData["auth-key"] = authKey
@@ -350,7 +363,7 @@ func interactiveSaveConfig(profileName string) error {
 		return err
 	}
 
-	return os.WriteFile(configPath, data, 0600) // 0600 for security (credentials)
+	return os.WriteFile(configPath, data, 0600)
 }
 
 var ErrTooLong = errors.New("input exceeds limit")


### PR DESCRIPTION
## Changes in this PR

Make things simpler for users. Repo configuration is now part of `orkes config save` (replaces `templates.yaml` with `config.yaml`).