### PR TITLE
Use CloudFront for templates

### DIFF
--- a/cmd/code.go
+++ b/cmd/code.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	defaultTemplateURL = "https://raw.githubusercontent.com/conductor-oss/cli-templates/main"
+	defaultTemplateURL = "https://d2ozrtblsovn5m.cloudfront.net"
 )
 
 func getTemplateBaseURL() string {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -259,7 +259,7 @@ func interactiveSaveConfig(profileName string) error {
 
 	templateURLDefault := existingConfig["template-url"]
 	if templateURLDefault == "" {
-		templateURLDefault = "https://raw.githubusercontent.com/conductor-oss/cli-templates/main"
+		templateURLDefault = "https://d2ozrtblsovn5m.cloudfront.net"
 	}
 	fmt.Fprintf(os.Stdout, "Template repo URL [%s]: ", templateURLDefault)
 	templateURLInput, _ := reader.ReadString('\n')


### PR DESCRIPTION
## Changes in this PR

Use CloudFront for templates instead of `https://raw.githubusercontent.com`