### PR TITLE
Add animated progress bar to download operations

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -29,6 +29,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/conductor-oss/conductor-cli/internal/progress"
 	"github.com/spf13/cobra"
 )
 
@@ -426,42 +427,16 @@ func downloadJar(jarPath, jarURL string) error {
 		return fmt.Errorf("download failed with status: %s", resp.Status)
 	}
 
-	// Get content length for progress
-	contentLength := resp.ContentLength
-	if contentLength > 0 {
-		fmt.Printf("Size: %.1f MB\n", float64(contentLength)/1024/1024)
+	// Show size and download with progress bar
+	if resp.ContentLength > 0 {
+		fmt.Printf("Size: %s\n", progress.FormatBytes(resp.ContentLength))
 	}
 
-	// Download with progress
-	var downloaded int64
-	buf := make([]byte, 32*1024)
-	lastProgress := -1
-
-	for {
-		n, err := resp.Body.Read(buf)
-		if n > 0 {
-			_, writeErr := tmpFile.Write(buf[:n])
-			if writeErr != nil {
-				return fmt.Errorf("failed to write file: %w", writeErr)
-			}
-			downloaded += int64(n)
-
-			// Show progress
-			if contentLength > 0 {
-				progress := int(float64(downloaded) / float64(contentLength) * 100)
-				if progress != lastProgress && progress%10 == 0 {
-					fmt.Printf("Progress: %d%%\n", progress)
-					lastProgress = progress
-				}
-			}
-		}
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return fmt.Errorf("download interrupted: %w", err)
-		}
+	pr, bar := progress.NewReader(resp.Body, resp.ContentLength, "Downloading")
+	if _, err := io.Copy(tmpFile, pr); err != nil {
+		return fmt.Errorf("download interrupted: %w", err)
 	}
+	bar.Finish()
 
 	// Close temp file before rename
 	tmpFile.Close()

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -72,8 +72,6 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to download binary: %w", err)
 	}
 
-	fmt.Printf("Downloaded %d bytes\n", len(binaryData))
-
 	// Apply the update (replace current binary)
 	fmt.Println("Applying update...")
 	err = goupdater.Apply(bytes.NewReader(binaryData), goupdater.Options{})

--- a/internal/progress/bar.go
+++ b/internal/progress/bar.go
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package progress
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+)
+
+const (
+	barWidth       = 30
+	filledChar     = "█"
+	emptyChar      = "░"
+	renderInterval = 100 * time.Millisecond
+)
+
+// ProgressBar tracks and renders download progress to stderr.
+type ProgressBar struct {
+	total       int64
+	current     int64
+	desc        string
+	mu          sync.Mutex
+	lastRender  time.Time
+	w           io.Writer
+}
+
+// NewProgressBar creates a new progress bar. If total <= 0, it renders without a bar.
+func NewProgressBar(total int64, desc string) *ProgressBar {
+	return &ProgressBar{
+		total: total,
+		desc:  desc,
+		w:     os.Stderr,
+	}
+}
+
+// Add advances the progress bar by n bytes.
+func (p *ProgressBar) Add(n int64) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.current += n
+	now := time.Now()
+	if now.Sub(p.lastRender) >= renderInterval {
+		p.render()
+		p.lastRender = now
+	}
+}
+
+// Finish renders the final state with a newline.
+func (p *ProgressBar) Finish() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.render()
+	fmt.Fprintln(p.w)
+}
+
+func (p *ProgressBar) render() {
+	if p.total > 0 {
+		pct := float64(p.current) / float64(p.total)
+		if pct > 1 {
+			pct = 1
+		}
+		filled := int(pct * float64(barWidth))
+		bar := ""
+		for i := 0; i < barWidth; i++ {
+			if i < filled {
+				bar += filledChar
+			} else {
+				bar += emptyChar
+			}
+		}
+		fmt.Fprintf(p.w, "\r%s  [%s]  %3.0f%%  %s/%s",
+			p.desc, bar, pct*100,
+			FormatBytes(p.current), FormatBytes(p.total))
+	} else {
+		fmt.Fprintf(p.w, "\r%s  %s downloaded", p.desc, FormatBytes(p.current))
+	}
+}
+
+// Reader wraps an io.Reader and reports progress on each Read.
+type Reader struct {
+	reader io.Reader
+	bar    *ProgressBar
+}
+
+// NewReader wraps r with a progress bar. desc is shown as a label.
+// If total <= 0, a simple byte counter is shown instead of a bar.
+func NewReader(r io.Reader, total int64, desc string) (*Reader, *ProgressBar) {
+	bar := NewProgressBar(total, desc)
+	return &Reader{reader: r, bar: bar}, bar
+}
+
+func (r *Reader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	if n > 0 {
+		r.bar.Add(int64(n))
+	}
+	return n, err
+}
+
+// FormatBytes returns a human-readable byte string (e.g. "12.3 MB").
+func FormatBytes(n int64) string {
+	const (
+		kb = 1024
+		mb = 1024 * kb
+		gb = 1024 * mb
+	)
+	switch {
+	case n >= gb:
+		return fmt.Sprintf("%.1f GB", float64(n)/float64(gb))
+	case n >= mb:
+		return fmt.Sprintf("%.1f MB", float64(n)/float64(mb))
+	case n >= kb:
+		return fmt.Sprintf("%.1f KB", float64(n)/float64(kb))
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}

--- a/internal/progress/bar_test.go
+++ b/internal/progress/bar_test.go
@@ -1,0 +1,106 @@
+package progress
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		input    int64
+		expected string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1048576, "1.0 MB"},
+		{26214400, "25.0 MB"},
+		{1073741824, "1.0 GB"},
+	}
+
+	for _, tt := range tests {
+		result := FormatBytes(tt.input)
+		if result != tt.expected {
+			t.Errorf("FormatBytes(%d) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestProgressBarKnownTotal(t *testing.T) {
+	var buf bytes.Buffer
+	bar := NewProgressBar(100, "Test")
+	bar.w = &buf
+	bar.lastRender = bar.lastRender // ensure zero time triggers render
+
+	bar.Add(50)
+	bar.Finish()
+
+	output := buf.String()
+	if !strings.Contains(output, "Test") {
+		t.Errorf("output should contain description, got: %q", output)
+	}
+	if !strings.Contains(output, "100%") {
+		// Finish should render final state
+		if !strings.Contains(output, "50") {
+			t.Errorf("output should contain progress info, got: %q", output)
+		}
+	}
+}
+
+func TestProgressBarUnknownTotal(t *testing.T) {
+	var buf bytes.Buffer
+	bar := NewProgressBar(0, "Test")
+	bar.w = &buf
+
+	bar.Add(1048576)
+	bar.Finish()
+
+	output := buf.String()
+	if !strings.Contains(output, "downloaded") {
+		t.Errorf("unknown total should show 'downloaded', got: %q", output)
+	}
+}
+
+func TestReaderWrapsRead(t *testing.T) {
+	data := "hello world, this is test data for the progress reader"
+	src := strings.NewReader(data)
+
+	var buf bytes.Buffer
+	pr, bar := NewReader(src, int64(len(data)), "Reading")
+	bar.w = &buf // redirect output
+
+	result, err := io.ReadAll(pr)
+	bar.Finish()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(result) != data {
+		t.Errorf("data mismatch: got %q, want %q", string(result), data)
+	}
+}
+
+func TestReaderZeroTotal(t *testing.T) {
+	data := "some data"
+	src := strings.NewReader(data)
+
+	var buf bytes.Buffer
+	pr, bar := NewReader(src, 0, "Download")
+	bar.w = &buf
+
+	result, err := io.ReadAll(pr)
+	bar.Finish()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(result) != data {
+		t.Errorf("data mismatch: got %q, want %q", string(result), data)
+	}
+	if !strings.Contains(buf.String(), "downloaded") {
+		t.Errorf("zero total should show 'downloaded', got: %q", buf.String())
+	}
+}

--- a/internal/updater/checker.go
+++ b/internal/updater/checker.go
@@ -22,6 +22,8 @@ import (
 	"net/http"
 	"runtime"
 	"time"
+
+	"github.com/conductor-oss/conductor-cli/internal/progress"
 )
 
 const (
@@ -181,5 +183,12 @@ func DownloadBinary(ctx context.Context, url string) ([]byte, error) {
 		return nil, fmt.Errorf("download failed with status %d", resp.StatusCode)
 	}
 
-	return io.ReadAll(resp.Body)
+	pr, bar := progress.NewReader(resp.Body, resp.ContentLength, "Downloading")
+	data, err := io.ReadAll(pr)
+	bar.Finish()
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                
  - Replace plain Progress: 10%, Progress: 20% text lines in server JAR download with an animated inline progress bar (Downloading  [████████████░░░░░░░░]  52%  12.3/24.1 MB)                                    
  - Add progress bar to CLI self-update (conductor update) which previously had no visual feedback                                                                                                                
  - Create shared internal/progress package (zero new dependencies) using \r carriage return to overwrite the terminal line                                                                                       

##   Changes

  - internal/progress/bar.go — New ProgressBar + Reader wrapper with rate-limited rendering (100ms), FormatBytes helper
  - internal/progress/bar_test.go — Unit tests for byte formatting, known/unknown total rendering, reader wrapper
  - cmd/server.go — Replace ~30-line manual chunked read loop with progress.NewReader + io.Copy
  - internal/updater/checker.go — Wrap resp.Body with progress reader in DownloadBinary()
  - cmd/update.go — Remove redundant "Downloaded N bytes" print

##   Test plan

  - go test ./internal/progress/... — all 5 unit tests pass
  - go build -o conductor . — compiles cleanly
  - ./conductor server update — animated progress bar during JAR download
  - ./conductor update — animated progress bar during CLI binary download
  - Verify unknown content-length falls back to byte counter (no bar)