### PR TITLE
Fix config save to default to OSS and skip auth prompts

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -262,7 +262,7 @@ func interactiveSaveConfig(profileName string) error {
 	// Prompt for server type
 	serverTypeDefault := existingConfig["server-type"]
 	if serverTypeDefault == "" {
-		serverTypeDefault = "Enterprise"
+		serverTypeDefault = "OSS"
 	}
 	fmt.Fprintf(os.Stdout, "Server type (OSS/Enterprise) [%s]: ", serverTypeDefault)
 	serverTypeInput, _ := reader.ReadString('\n')
@@ -284,68 +284,73 @@ func interactiveSaveConfig(profileName string) error {
 		templateURL = templateURLInput
 	}
 
-	// Prompt for auth method
-	fmt.Fprintf(os.Stdout, "\nAuthentication method:\n")
-	fmt.Fprintf(os.Stdout, "  1. API Key + Secret\n")
-	fmt.Fprintf(os.Stdout, "  2. Auth Token\n")
-
-	// Determine default auth method based on existing config
-	defaultAuthMethod := "1"
-	if existingConfig["auth-token"] != "" {
-		defaultAuthMethod = "2"
-	}
-
-	fmt.Fprintf(os.Stdout, "Choose [%s]: ", defaultAuthMethod)
-	authMethodInput, _ := reader.ReadString('\n')
-	authMethodInput = strings.TrimSpace(authMethodInput)
-	authMethod := defaultAuthMethod
-	if authMethodInput != "" {
-		authMethod = authMethodInput
-	}
-
 	var authKey, authSecret, authToken string
 
-	if authMethod == "1" {
-		// API Key + Secret
-		authKeyDefault := existingConfig["auth-key"]
-		if authKeyDefault != "" {
-			authKeyDefault = "****" // Mask existing key
-		}
-		fmt.Fprintf(os.Stdout, "API Key [%s]: ", authKeyDefault)
-		authKeyInput, _ := reader.ReadString('\n')
-		authKeyInput = strings.TrimSpace(authKeyInput)
-		if authKeyInput != "" {
-			authKey = authKeyInput
-		} else if existingConfig["auth-key"] != "" {
-			authKey = existingConfig["auth-key"]
+	// Only prompt for authentication when using Enterprise server
+	if strings.EqualFold(serverType, "OSS") {
+		fmt.Fprintf(os.Stdout, "\nNo authentication required for OSS Conductor.\n")
+	} else {
+		// Prompt for auth method
+		fmt.Fprintf(os.Stdout, "\nAuthentication method:\n")
+		fmt.Fprintf(os.Stdout, "  1. API Key + Secret\n")
+		fmt.Fprintf(os.Stdout, "  2. Auth Token\n")
+
+		// Determine default auth method based on existing config
+		defaultAuthMethod := "1"
+		if existingConfig["auth-token"] != "" {
+			defaultAuthMethod = "2"
 		}
 
-		authSecretDefault := existingConfig["auth-secret"]
-		if authSecretDefault != "" {
-			authSecretDefault = "****" // Mask existing secret
+		fmt.Fprintf(os.Stdout, "Choose [%s]: ", defaultAuthMethod)
+		authMethodInput, _ := reader.ReadString('\n')
+		authMethodInput = strings.TrimSpace(authMethodInput)
+		authMethod := defaultAuthMethod
+		if authMethodInput != "" {
+			authMethod = authMethodInput
 		}
-		fmt.Fprintf(os.Stdout, "API Secret [%s]: ", authSecretDefault)
-		authSecretInput, _ := reader.ReadString('\n')
-		authSecretInput = strings.TrimSpace(authSecretInput)
-		if authSecretInput != "" {
-			authSecret = authSecretInput
-		} else if existingConfig["auth-secret"] != "" {
-			authSecret = existingConfig["auth-secret"]
-		}
-	} else {
-		// Auth Token
-		authTokenDefault := existingConfig["auth-token"]
-		if authTokenDefault != "" {
-			authTokenDefault = "****" // Mask existing token
-		}
-		fmt.Fprintf(os.Stdout, "Auth Token [%s]: ", authTokenDefault)
-		authTokenInput, _ := ReadLineRaw(8192)
-		fmt.Println()
-		authTokenInput = strings.TrimSpace(authTokenInput)
-		if authTokenInput != "" {
-			authToken = authTokenInput
-		} else if existingConfig["auth-token"] != "" {
-			authToken = existingConfig["auth-token"]
+
+		if authMethod == "1" {
+			// API Key + Secret
+			authKeyDefault := existingConfig["auth-key"]
+			if authKeyDefault != "" {
+				authKeyDefault = "****" // Mask existing key
+			}
+			fmt.Fprintf(os.Stdout, "API Key [%s]: ", authKeyDefault)
+			authKeyInput, _ := reader.ReadString('\n')
+			authKeyInput = strings.TrimSpace(authKeyInput)
+			if authKeyInput != "" {
+				authKey = authKeyInput
+			} else if existingConfig["auth-key"] != "" {
+				authKey = existingConfig["auth-key"]
+			}
+
+			authSecretDefault := existingConfig["auth-secret"]
+			if authSecretDefault != "" {
+				authSecretDefault = "****" // Mask existing secret
+			}
+			fmt.Fprintf(os.Stdout, "API Secret [%s]: ", authSecretDefault)
+			authSecretInput, _ := reader.ReadString('\n')
+			authSecretInput = strings.TrimSpace(authSecretInput)
+			if authSecretInput != "" {
+				authSecret = authSecretInput
+			} else if existingConfig["auth-secret"] != "" {
+				authSecret = existingConfig["auth-secret"]
+			}
+		} else {
+			// Auth Token
+			authTokenDefault := existingConfig["auth-token"]
+			if authTokenDefault != "" {
+				authTokenDefault = "****" // Mask existing token
+			}
+			fmt.Fprintf(os.Stdout, "Auth Token [%s]: ", authTokenDefault)
+			authTokenInput, _ := ReadLineRaw(8192)
+			fmt.Println()
+			authTokenInput = strings.TrimSpace(authTokenInput)
+			if authTokenInput != "" {
+				authToken = authTokenInput
+			} else if existingConfig["auth-token"] != "" {
+				authToken = existingConfig["auth-token"]
+			}
 		}
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -114,7 +114,7 @@ var rootCmd = &cobra.Command{
 
 		// Set default server type if not provided
 		if serverType == "" {
-			serverType = "Enterprise"
+			serverType = "OSS"
 		}
 
 		// Auto-detect server if not configured


### PR DESCRIPTION
## Summary

- **Default server type changed from Enterprise to OSS** in the interactive `config save` flow and in the root command fallback
- **Auth prompts (API key/secret, auth token) are now skipped** when the server type is OSS, since OSS Conductor doesn't require authentication
- Enterprise users are unaffected — full auth prompts remain when Enterprise is selected

## Problem

Running `conductor config save` as a new OSS user would:
1. Default to "Enterprise" server type, requiring the user to manually change it
2. Always prompt for API key/secret or auth token, even after selecting OSS
3. This broke the quickstart flow — new users hitting Enter through defaults would end up with an Enterprise config that fails against their OSS server

## Test plan

- [ ] Run `conductor config save` and verify it defaults to OSS
- [ ] Confirm pressing Enter through all prompts produces a working OSS config (no auth fields)
- [ ] Run `conductor config save`, choose Enterprise, and verify auth prompts still appear
- [ ] Verify existing Enterprise configs are not affected when re-saving