### PR TITLE
Improve post-install messaging and server startup UX

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -694,7 +694,8 @@ func startServer(cmd *cobra.Command, args []string) error {
 	} else {
 		fmt.Printf("\nConductor server is ready!\n")
 		fmt.Printf("  API: http://localhost:%d/api\n", port)
-		fmt.Printf("  UI:  http://localhost:%d\n", port)
+		fmt.Printf("  UI:  http://localhost:%d\n\n", port)
+		fmt.Printf("Open http://localhost:%d in your browser to access the Conductor UI\n", port)
 	}
 
 	fmt.Printf("\nUse 'conductor server stop' to stop the server\n")
@@ -994,7 +995,8 @@ func startLocalServer(port int) error {
 
 	fmt.Printf("\nConductor server is ready!\n")
 	fmt.Printf("  API: http://localhost:%d/api\n", port)
-	fmt.Printf("  UI:  http://localhost:%d\n", port)
+	fmt.Printf("  UI:  http://localhost:%d\n\n", port)
+	fmt.Printf("Open http://localhost:%d in your browser to access the Conductor UI\n", port)
 
 	// Detach the process
 	go func() {

--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -126,14 +126,6 @@ var (
 		Use:          "start",
 		Short:        "Start workflow execution",
 		Long:         "Start workflow execution. Use --sync flag to execute synchronously and wait for completion.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			sync, _ := cmd.Flags().GetBool("sync")
-			version, _ := cmd.Flags().GetInt32("version")
-			if sync && version == 0 {
-				return fmt.Errorf("--version is required when using --sync flag")
-			}
-			return nil
-		},
 		RunE:         startWorkflow,
 		SilenceUsage: true,
 		Example:      "workflow start --workflow my_workflow\nworkflow start --workflow my_workflow --sync --version 1",

--- a/install.js
+++ b/install.js
@@ -109,7 +109,10 @@ async function install() {
 
     console.log('Installation successful!');
     console.log(`Binary installed at: ${binaryPath}`);
-    console.log(`\nRun 'conductor --version' to verify installation.`);
+    console.log('');
+    console.log('Get started:');
+    console.log('  conductor server start   Start a local Conductor server');
+    console.log('  conductor --help          See all available commands');
   } catch (error) {
     console.error('Installation failed:', error.message);
     process.exit(1);

--- a/install.ps1
+++ b/install.ps1
@@ -56,4 +56,7 @@ Write-Host "Conductor CLI $version installed successfully!" -ForegroundColor Gre
 Write-Host "Location: $exePath"
 Write-Host ""
 Write-Host "Restart your terminal, then run:" -ForegroundColor Yellow
-Write-Host "  conductor --version"
+Write-Host ""
+Write-Host "Get started:" -ForegroundColor Green
+Write-Host "  conductor server start   Start a local Conductor server" -ForegroundColor Yellow
+Write-Host "  conductor --help          See all available commands" -ForegroundColor Yellow

--- a/install.sh
+++ b/install.sh
@@ -91,7 +91,9 @@ verify_installation() {
         echo "${GREEN}Installation successful!${NC}"
         echo "${GREEN}  Version: $VERSION_OUTPUT${NC}"
         echo ""
-        echo "Run '${BINARY_NAME} --help' to get started."
+        echo "${GREEN}Get started:${NC}"
+        echo "  ${YELLOW}conductor server start${NC}   Start a local Conductor server"
+        echo "  ${YELLOW}conductor --help${NC}          See all available commands"
     else
         echo "${YELLOW}Binary installed but not found in PATH${NC}"
         echo "You may need to add $INSTALL_DIR to your PATH:"


### PR DESCRIPTION
Summary

  - Updated install scripts (install.sh, install.ps1, install.js) to show actionable "Get started" instructions after installation, pointing users to conductor server start instead of just conductor --version
  - Added a browser prompt message after server starts successfully ("Open http://localhost:PORT in your browser to access the Conductor UI")
  - Removed the incorrect --version requirement when using --sync flag for workflow start

  Changes

  - install.sh / install.ps1 / install.js: Replace post-install hint with conductor server start + conductor --help as first steps
  - cmd/server.go: Add explicit browser open prompt in both startServer and startLocalServer after server is ready
  - cmd/workflow.go: Remove PreRunE validation that incorrectly required --version when using --sync