### PR TITLE
fix: show active env vars in verbose mode and include source in auth errors

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -285,9 +285,29 @@ func initConfig() {
 		viper.BindEnv("server-type", "CONDUCTOR_SERVER_TYPE")
 	}
 
+	// Determine if env vars are the active config source (no profile selected)
+	usingEnvVars := profile == "" && os.Getenv("CONDUCTOR_PROFILE") == ""
+
+	if viper.GetBool("verbose") && usingEnvVars {
+		for _, ev := range []string{"CONDUCTOR_SERVER_URL", "CONDUCTOR_AUTH_TOKEN", "CONDUCTOR_AUTH_KEY", "CONDUCTOR_AUTH_SECRET", "CONDUCTOR_SERVER_TYPE"} {
+			if v := os.Getenv(ev); v != "" {
+				switch ev {
+				case "CONDUCTOR_AUTH_TOKEN", "CONDUCTOR_AUTH_SECRET":
+					fmt.Fprintf(os.Stdout, "Using env var %s: (set)\n", ev)
+				default:
+					fmt.Fprintf(os.Stdout, "Using env var %s: %s\n", ev, v)
+				}
+			}
+		}
+	}
+
 	if err := viper.ReadInConfig(); err == nil {
 		if viper.GetBool("verbose") {
-			fmt.Fprintf(os.Stdout, "Using config file: %s\n", viper.ConfigFileUsed())
+			// When CONDUCTOR_SERVER_URL env var is active, suppress the config file message
+			// to avoid confusion about which source the server URL came from.
+			if !usingEnvVars || os.Getenv("CONDUCTOR_SERVER_URL") == "" {
+				fmt.Fprintf(os.Stdout, "Using config file: %s\n", viper.ConfigFileUsed())
+			}
 		}
 	}
 }

--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -589,7 +589,11 @@ func parseAPIError(err error, defaultMsg string) error {
 				if message == "" {
 					message = "Authentication failed"
 				}
-				return fmt.Errorf("%s\nPlease check your authentication settings. Run 'conductor config save' to configure credentials", message)
+				hint := "Please check your authentication settings. Run 'conductor config save' to configure credentials"
+			if envURL := os.Getenv("CONDUCTOR_SERVER_URL"); envURL != "" {
+				hint += fmt.Sprintf("\nNote: Server URL is set via CONDUCTOR_SERVER_URL=%s", envURL)
+			}
+			return fmt.Errorf("%s\n%s", message, hint)
 			}
 
 			if errorResponse.Message != "" {


### PR DESCRIPTION
fix: show active env vars in verbose mode and include source in auth errors. E.g.:

<img width="680" height="100" alt="Screenshot 2026-03-24 at 15 43 42" src="https://github.com/user-attachments/assets/caba196d-794c-42d2-af17-bf44acd21011" />
