### PR TITLE
docs: add Java 21 prerequisite and PATH guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,13 @@ conductor api-gateway route <command> [arguments] [flags]
 
 Manage a local Conductor server for development.
 
+> **Prerequisite:** `conductor server start` downloads and runs a local Conductor server JAR. This requires **Java 21 or higher** in your PATH.
+> - macOS: `brew install openjdk@21 && export JAVA_HOME=$(brew --prefix openjdk@21)`
+> - Ubuntu/Debian: `sudo apt install openjdk-21-jdk`
+> - Windows: Download from https://adoptium.net/
+>
+> Note: `brew install openjdk@21` installs Java but does not link it to your PATH by default — the `export JAVA_HOME` step above is required on macOS.
+
 ```
 conductor server <command> [flags]
 ```

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -580,7 +580,7 @@ func startServer(cmd *cobra.Command, args []string) error {
 	}
 
 	if javaVersion < minJavaVersion {
-		return fmt.Errorf("Java %d is installed, but Java %d or higher is required.\n\nPlease upgrade your Java installation:\n  - macOS: brew install openjdk@21\n  - Ubuntu/Debian: sudo apt install openjdk-21-jdk\n  - Windows: Download from https://adoptium.net/", javaVersion, minJavaVersion)
+		return fmt.Errorf("Java %d is installed, but Java %d or higher is required.\n\nPlease upgrade your Java installation:\n  - macOS: brew install openjdk@21\n  - Ubuntu/Debian: sudo apt install openjdk-21-jdk\n  - Windows: Download from https://adoptium.net/\n\nIf you already have Java 21+ installed but it is not in PATH (common on macOS after Homebrew install):\n  export JAVA_HOME=$(brew --prefix openjdk@21)\n  export PATH=\"$JAVA_HOME/bin:$PATH\"", javaVersion, minJavaVersion)
 	}
 
 	fmt.Printf("Java %d detected\n", javaVersion)
@@ -911,7 +911,7 @@ func startLocalServer(port int) error {
 	}
 
 	if javaVersion < minJavaVersion {
-		return fmt.Errorf("Java %d is installed, but Java %d or higher is required.\n\nPlease upgrade your Java installation:\n  - macOS: brew install openjdk@21\n  - Ubuntu/Debian: sudo apt install openjdk-21-jdk\n  - Windows: Download from https://adoptium.net/", javaVersion, minJavaVersion)
+		return fmt.Errorf("Java %d is installed, but Java %d or higher is required.\n\nPlease upgrade your Java installation:\n  - macOS: brew install openjdk@21\n  - Ubuntu/Debian: sudo apt install openjdk-21-jdk\n  - Windows: Download from https://adoptium.net/\n\nIf you already have Java 21+ installed but it is not in PATH (common on macOS after Homebrew install):\n  export JAVA_HOME=$(brew --prefix openjdk@21)\n  export PATH=\"$JAVA_HOME/bin:$PATH\"", javaVersion, minJavaVersion)
 	}
 
 	fmt.Printf("Java %d detected\n", javaVersion)


### PR DESCRIPTION
Fixes conductor-oss/getting-started#2

## Summary

- Adds a prerequisite callout to the Server Commands section in README.md explaining that `conductor server start` requires Java 21+, with install instructions for macOS, Linux, and Windows
- Includes the macOS `export JAVA_HOME` step that Homebrew omits by default — the most common failure mode
- Extends both Java version mismatch error messages in `cmd/server.go` to include PATH/JAVA_HOME guidance for users who have Java 21 installed but not linked

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Run `conductor server start` with Java 17 installed, confirm new error message includes the `export JAVA_HOME` hint
- [ ] Run `conductor server start` with Java 21 installed and not in PATH, confirm error is actionable