### PR TITLE
docs: document conductor code command and interactive-only limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,6 +532,22 @@ conductor config <command> [arguments] [flags]
 
 ---
 
+### Code Generation Commands
+
+Generate worker scaffold code for a given language and template.
+
+```
+conductor code [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `-l, --lang` | Programming language (e.g. `python`, `java`, `go`) |
+| `-t, --template` | Template name |
+| `-n, --name` | Project name |
+
+> **Note:** `conductor code` prompts interactively for any fields not supplied as flags (including task name). It cannot be used non-interactively via pipe or in CI — passing all inputs via flags is not yet fully supported. Use `conductor code list` to see available templates.
+
 ### Other Commands
 
 | Command | Description |


### PR DESCRIPTION
Fixes conductor-oss/getting-started#17

Adds a `conductor code` section to the README documenting available flags and noting that task name (and other unprovided fields) are prompted interactively — the command cannot currently be run non-interactively via pipe or in CI.