### PR TITLE
fix: OSS usability improvements (whoami, workflow create, code gen)

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,6 +532,22 @@ conductor config <command> [arguments] [flags]
 
 ---
 
+### Code Generation Commands
+
+Generate worker scaffold code for a given language and template.
+
+```
+conductor code [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `-l, --lang` | Programming language (e.g. `python`, `java`, `go`) |
+| `-t, --template` | Template name |
+| `-n, --name` | Project name |
+
+> **Note:** `conductor code` prompts interactively for any fields not supplied as flags (including task name). It cannot be used non-interactively via pipe or in CI — passing all inputs via flags is not yet fully supported. Use `conductor code list` to see available templates.
+
 ### Other Commands
 
 | Command | Description |

--- a/cmd/code.go
+++ b/cmd/code.go
@@ -269,10 +269,11 @@ func buildTemplateContext(fields []Field, reader *bufio.Reader) (map[string]inte
 	}
 
 	serverURL := viper.GetString("server")
-	if serverURL != "" {
-		context["server_url"] = serverURL
-		context["server"] = serverURL
+	if serverURL == "" {
+		serverURL = "http://localhost:8080/api"
 	}
+	context["server_url"] = serverURL
+	context["server"] = serverURL
 
 	authKey := viper.GetString("auth-key")
 	if authKey != "" {

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -48,7 +48,10 @@ var whoamiCmd = &cobra.Command{
 			}
 			jwtToken = tokenResponse.Token
 		} else {
-			return fmt.Errorf("no authentication configured - please configure auth-token or auth-key/auth-secret")
+			// No auth configured — normal for OSS Conductor
+			fmt.Printf("Server:         %s\n", url)
+			fmt.Println("Authentication: none (OSS Conductor)")
+			return nil
 		}
 
 		// Print server URL

--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -443,6 +443,7 @@ func registerWorkflow(data []byte, force bool) error {
 	if err != nil {
 		return parseAPIError(err, "Failed to create workflow")
 	}
+	fmt.Printf("Workflow '%s' version %d registered successfully\n", workflowDef.Name, workflowDef.Version)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- **#4** `conductor workflow create`: Add success message after registration (was silent on success)
- **#16** `conductor whoami`: Gracefully handle no-auth OSS configuration instead of erroring out; shows server URL and notes OSS mode
- **#15** `conductor code`: Default `server_url` to `http://localhost:8080/api` when no server is configured, so generated projects connect out of the box

## Details

### workflow create (#4)
`registerWorkflow` now prints `Workflow '<name>' version <N> registered successfully` on success.

### whoami (#16)
When no auth is configured (normal for OSS Conductor), `whoami` now shows:
```
Server:         http://localhost:8080/api
Authentication: none (OSS Conductor)
```
Instead of an error.

### code default server_url (#15)
When no `CONDUCTOR_SERVER_URL` env var or config file is set, generated code now gets `http://localhost:8080/api` as the server URL instead of an empty string. This pairs with CLI template fixes in conductor-oss/cli-templates.

## Related issues
Closes conductor-oss/getting-started#4
Closes conductor-oss/getting-started#16
Partially addresses conductor-oss/getting-started#15

🤖 Generated with [Claude Code](https://claude.com/claude-code)