### PR TITLE
fix: rename get_all to get-all for CLI naming consistency

### DIFF
--- a/cmd/task.go
+++ b/cmd/task.go
@@ -73,7 +73,8 @@ var (
 	}
 
 	getAllTaskMetadataCmd = &cobra.Command{
-		Use:          "get_all",
+		Use:          "get-all",
+		Aliases:      []string{"get_all"},
 		Short:        "Get all task definitions",
 		RunE:         getAllTasks,
 		SilenceUsage: true,

--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -68,7 +68,8 @@ var (
 	}
 
 	getAllWorkflowMetadataCmd = &cobra.Command{
-		Use:          "get_all",
+		Use:          "get-all",
+		Aliases:      []string{"get_all"},
 		Short:        "Get All Workflows",
 		RunE:         getAllWorkflowMetadata,
 		SilenceUsage: true,


### PR DESCRIPTION
## Summary

- Renames `workflow get_all` → `workflow get-all`
- Renames `task get_all` → `task get-all`
- Keeps `get_all` as a Cobra alias for backwards compatibility

Standardizes on hyphens (Go/POSIX CLI convention), matching all other subcommands (`get-execution`, `delete-execution`, `update-state`, `update-execution`).

## User impact

New users following docs or tab-completing commands would hit an inconsistency: some subcommands used underscores, others hyphens. Now everything is hyphens. The `get_all` alias means existing scripts don't break.

Fixes conductor-oss/getting-started#19

🤖 Generated with [Claude Code](https://claude.com/claude-code)