### PR TITLE
fix: label api-gateway and worker remote as Orkes-only

### DIFF
--- a/cmd/api_gateway.go
+++ b/cmd/api_gateway.go
@@ -35,7 +35,7 @@ var (
 	apiGatewayCmd = &cobra.Command{
 		Use:     "api-gateway",
 		Short:   "API Gateway management commands",
-		Long:    "Manage API Gateway services, routes, and authentication configurations.",
+		Long:    "Manage API Gateway services, routes, and authentication configurations.\n\n⚠️  Requires Orkes Conductor. Not available in OSS Conductor.",
 		GroupID: "conductor",
 	}
 

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -98,7 +98,9 @@ Exit codes:
 	workerRemoteCmd = &cobra.Command{
 		Use:   "remote",
 		Short: "Run a worker from the job-runner registry (EXPERIMENTAL)",
-		Long: `⚠️  EXPERIMENTAL FEATURE - Download and execute a worker from the Orkes Conductor job-runner.
+		Long: `⚠️  EXPERIMENTAL FEATURE - Requires Orkes Conductor. Not available in OSS Conductor.
+
+Download and execute a worker from the Orkes Conductor job-runner.
 
 The worker is downloaded from the configured Conductor server and cached locally for
 subsequent runs. Use --refresh to force re-download from the registry.


### PR DESCRIPTION
## Summary

- Adds `⚠️ Requires Orkes Conductor. Not available in OSS Conductor.` to the `api-gateway` command Long text
- Updates `worker remote` Long text to lead with the Orkes-only requirement

## User impact

An OSS user who runs `conductor api-gateway --help` or `conductor worker remote --help` gets no indication that these commands require an enterprise server. They'd try them, get a cryptic connection or 404 error, and have no idea why. Now the first thing they read is a clear restriction notice.

Fixes conductor-oss/getting-started#20

🤖 Generated with [Claude Code](https://claude.com/claude-code)