### PR TITLE
fix: --sync falls back to StartWorkflow+poll on OSS Conductor

### DIFF
--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -1093,36 +1093,84 @@ func startWorkflow(cmd *cobra.Command, args []string) error {
 
 	// Synchronous execution
 	if sync {
-		requestId, _ := uuid.NewRandom()
-		request := model.StartWorkflowRequest{
-			Name:          workflowName,
-			Version:       version,
-			CorrelationId: correlationId,
-			Input:         inputMap,
-			Priority:      0,
-		}
-
 		waitUntil, _ := cmd.Flags().GetString("wait-until")
+		full, _ := cmd.Flags().GetBool("full")
 		log.Debug("wait until ", waitUntil)
 
-		run, _, execErr := workflowClient.ExecuteWorkflow(context.Background(), request, requestId.String(), workflowName, version, waitUntil)
-		if execErr != nil {
-			return parseAPIError(execErr, "Failed to start workflow")
+		// ExecuteWorkflow (POST /api/workflow/execute/{name}/{version}) is only
+		// available when auth is configured (Orkes Conductor). If no credentials
+		// are set, skip straight to the OSS-compatible start + poll path.
+		authKey := viper.GetString("auth-key")
+		authToken := viper.GetString("auth-token")
+		if authKey != "" || authToken != "" {
+			requestId, _ := uuid.NewRandom()
+			request := model.StartWorkflowRequest{
+				Name:          workflowName,
+				Version:       version,
+				CorrelationId: correlationId,
+				Input:         inputMap,
+				Priority:      0,
+			}
+			run, _, execErr := workflowClient.ExecuteWorkflow(context.Background(), request, requestId.String(), workflowName, version, waitUntil)
+			if execErr == nil {
+				var printTarget interface{}
+				if full {
+					printTarget = run
+				} else {
+					printTarget = run.Output
+				}
+				data, jsonError := json.MarshalIndent(printTarget, "", "   ")
+				if jsonError != nil {
+					return jsonError
+				}
+				fmt.Println(string(data))
+				return nil
+			}
+			log.Debug("ExecuteWorkflow unavailable, falling back to StartWorkflow + poll: ", execErr)
 		}
 
-		full, _ := cmd.Flags().GetBool("full")
-		var printTarget interface{}
-		if full {
-			printTarget = run
-		} else {
-			printTarget = run.Output
+		// OSS path (or Orkes fallback): start async, then poll until terminal.
+		startOpts := &client.WorkflowResourceApiStartWorkflowOpts{}
+		if version > 0 {
+			startOpts.Version = optional.NewInt32(version)
 		}
-		data, jsonError := json.MarshalIndent(printTarget, "", "   ")
-		if jsonError != nil {
-			return jsonError
+		if correlationId != "" {
+			startOpts.CorrelationId = optional.NewString(correlationId)
 		}
-		fmt.Println(string(data))
-		return nil
+		workflowId, _, startErr := workflowClient.StartWorkflow(cmd.Context(), inputMap, workflowName, startOpts)
+		if startErr != nil {
+			return parseAPIError(startErr, "Failed to start workflow")
+		}
+
+		pollOpts := &client.WorkflowResourceApiGetExecutionStatusOpts{IncludeTasks: optional.NewBool(false)}
+		for {
+			wf, _, pollErr := workflowClient.GetExecutionStatus(context.Background(), workflowId, pollOpts)
+			if pollErr != nil {
+				return parseAPIError(pollErr, "Failed to get workflow status")
+			}
+			isTerminal := false
+			for _, s := range model.WorkflowTerminalStates {
+				if wf.Status == s {
+					isTerminal = true
+					break
+				}
+			}
+			if isTerminal {
+				var printTarget interface{}
+				if full {
+					printTarget = wf
+				} else {
+					printTarget = wf.Output
+				}
+				data, jsonError := json.MarshalIndent(printTarget, "", "   ")
+				if jsonError != nil {
+					return jsonError
+				}
+				fmt.Println(string(data))
+				return nil
+			}
+			time.Sleep(500 * time.Millisecond)
+		}
 	}
 
 	// Asynchronous execution

--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -1066,36 +1066,84 @@ func startWorkflow(cmd *cobra.Command, args []string) error {
 
 	// Synchronous execution
 	if sync {
-		requestId, _ := uuid.NewRandom()
-		request := model.StartWorkflowRequest{
-			Name:          workflowName,
-			Version:       version,
-			CorrelationId: correlationId,
-			Input:         inputMap,
-			Priority:      0,
-		}
-
 		waitUntil, _ := cmd.Flags().GetString("wait-until")
+		full, _ := cmd.Flags().GetBool("full")
 		log.Debug("wait until ", waitUntil)
 
-		run, _, execErr := workflowClient.ExecuteWorkflow(context.Background(), request, requestId.String(), workflowName, version, waitUntil)
-		if execErr != nil {
-			return parseAPIError(execErr, "Failed to start workflow")
+		// ExecuteWorkflow (POST /api/workflow/execute/{name}/{version}) is only
+		// available when auth is configured (Orkes Conductor). If no credentials
+		// are set, skip straight to the OSS-compatible start + poll path.
+		authKey := viper.GetString("auth-key")
+		authToken := viper.GetString("auth-token")
+		if authKey != "" || authToken != "" {
+			requestId, _ := uuid.NewRandom()
+			request := model.StartWorkflowRequest{
+				Name:          workflowName,
+				Version:       version,
+				CorrelationId: correlationId,
+				Input:         inputMap,
+				Priority:      0,
+			}
+			run, _, execErr := workflowClient.ExecuteWorkflow(context.Background(), request, requestId.String(), workflowName, version, waitUntil)
+			if execErr == nil {
+				var printTarget interface{}
+				if full {
+					printTarget = run
+				} else {
+					printTarget = run.Output
+				}
+				data, jsonError := json.MarshalIndent(printTarget, "", "   ")
+				if jsonError != nil {
+					return jsonError
+				}
+				fmt.Println(string(data))
+				return nil
+			}
+			log.Debug("ExecuteWorkflow unavailable, falling back to StartWorkflow + poll: ", execErr)
 		}
 
-		full, _ := cmd.Flags().GetBool("full")
-		var printTarget interface{}
-		if full {
-			printTarget = run
-		} else {
-			printTarget = run.Output
+		// OSS path (or Orkes fallback): start async, then poll until terminal.
+		startOpts := &client.WorkflowResourceApiStartWorkflowOpts{}
+		if version > 0 {
+			startOpts.Version = optional.NewInt32(version)
 		}
-		data, jsonError := json.MarshalIndent(printTarget, "", "   ")
-		if jsonError != nil {
-			return jsonError
+		if correlationId != "" {
+			startOpts.CorrelationId = optional.NewString(correlationId)
 		}
-		fmt.Println(string(data))
-		return nil
+		workflowId, _, startErr := workflowClient.StartWorkflow(cmd.Context(), inputMap, workflowName, startOpts)
+		if startErr != nil {
+			return parseAPIError(startErr, "Failed to start workflow")
+		}
+
+		pollOpts := &client.WorkflowResourceApiGetExecutionStatusOpts{IncludeTasks: optional.NewBool(false)}
+		for {
+			wf, _, pollErr := workflowClient.GetExecutionStatus(context.Background(), workflowId, pollOpts)
+			if pollErr != nil {
+				return parseAPIError(pollErr, "Failed to get workflow status")
+			}
+			isTerminal := false
+			for _, s := range model.WorkflowTerminalStates {
+				if wf.Status == s {
+					isTerminal = true
+					break
+				}
+			}
+			if isTerminal {
+				var printTarget interface{}
+				if full {
+					printTarget = wf
+				} else {
+					printTarget = wf.Output
+				}
+				data, jsonError := json.MarshalIndent(printTarget, "", "   ")
+				if jsonError != nil {
+					return jsonError
+				}
+				fmt.Println(string(data))
+				return nil
+			}
+			time.Sleep(500 * time.Millisecond)
+		}
 	}
 
 	// Asynchronous execution


### PR DESCRIPTION
## Summary

Main currently calls `ExecuteWorkflow` unconditionally for `--sync`, which requires the Orkes-only `/api/workflow/execute/{name}/{version}` endpoint. On OSS Conductor that returns an error and `--sync` fails with no workflow actually started — defeating the whole flag.

This PR:
- When no auth credentials are configured (heuristic for OSS), skip `ExecuteWorkflow` and go straight to `StartWorkflow` + polling `GetExecutionStatus` until a terminal state.
- When auth is configured, try `ExecuteWorkflow` first and fall back to the poll path if it errors — so a self-hosted OSS server with stray auth configured still works.
- Output shape is preserved: default prints `wf.Output` (same as `run.Output`); `--full` prints the full `Workflow`/`WorkflowRun` envelope.

## Rebase note

This branch has been rebased onto the current main. The `--full` flag and default-to-output behavior already landed on main via 94f7f9c, so this PR now contains **only** the OSS fallback logic as a single commit on top of current main. The previous branch had a `key`/`token` reference bug that wouldn't compile — that's fixed here (properly reads `viper.GetString("auth-key")` / `"auth-token"`).

## User impact

OSS users running `conductor workflow start --workflow foo --sync` now actually get a running workflow and see its output when it completes. Previously the command failed with a 404/405 from a missing Orkes endpoint.

Fixes conductor-oss/getting-started#52