### PR TITLE
test: update e2e workflow --sync assertions to match new output shape

### DIFF
--- a/test/e2e/workflow.bats
+++ b/test/e2e/workflow.bats
@@ -43,18 +43,30 @@ get_workflow_id() {
 }
 
 @test "4. Start workflow execution with --sync --version 1" {
+    # Default --sync prints only run.Output (JSON); --full prints the complete WorkflowRun.
     run bash -c "./conductor workflow start --workflow '$WORKFLOW_NAME_2' --sync --version 1 2>/dev/null"
     echo "Output: $output"
     [ "$status" -eq 0 ]
 
-    # Output should be JSON (workflow execution details), not just a UUID
-    [[ "$output" == *"\"status\""* ]]
-    [[ "$output" == *"\"workflowId\""* ]]
-    [[ "$output" == *"$WORKFLOW_NAME_2"* ]]
+    # Output should be the workflow's output JSON — not a UUID, not the full WorkflowRun envelope.
+    [[ "$output" == *"\"result\""* ]]
+    [[ "$output" == *"CLI TEST"* ]]
+    [[ "$output" != *"\"workflowId\""* ]]
 
     # Should NOT be just a single line UUID
     line_count=$(echo "$output" | wc -l | tr -d ' ')
     [ "$line_count" -gt 1 ]
+}
+
+@test "4b. Start workflow execution with --sync --full prints complete WorkflowRun" {
+    run bash -c "./conductor workflow start --workflow '$WORKFLOW_NAME_2' --sync --full --version 1 2>/dev/null"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+
+    # --full returns the complete WorkflowRun JSON (status, workflowId, etc.)
+    [[ "$output" == *"\"status\""* ]]
+    [[ "$output" == *"\"workflowId\""* ]]
+    [[ "$output" == *"$WORKFLOW_NAME_2"* ]]
 }
 
 @test "5. Cleanup - delete workflow definition for sync test" {


### PR DESCRIPTION
## Summary

Commit 94f7f9c (fix: label Orkes-only commands; print workflow output by default with --sync) changed \`--sync\` to print only \`run.Output\` by default and added \`--full\` for the complete \`WorkflowRun\` JSON, but \`workflow.bats\` test 4 still asserted the old envelope fields (\`\"status\"\`, \`\"workflowId\"\`).

- Test 4 now checks for the workflow output (\`\"result\": \"CLI TEST\"\`) and asserts \`\"workflowId\"\` is absent — proving we're past the UUID-only path and not getting the full envelope by default.
- New test 4b exercises \`--sync --full\` to verify the complete-envelope path still works.

## User impact

This was the only failing test on main's E2E Tests run, so E2E has looked red on every branch for about a week even though the CLI itself is fine. Fixing the test turns E2E green and unblocks CI signal on PRs #79, #80, #82, and #83.