### PR TITLE
fix: warn about ~600 MB download before first server start

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -598,6 +598,8 @@ func startServer(cmd *cobra.Command, args []string) error {
 	}
 
 	if _, err := os.Stat(jarPath); os.IsNotExist(err) {
+		fmt.Println("First run: downloading the Conductor server JAR (~600 MB). This may take a few minutes.")
+		fmt.Println("Tip: for a faster start, use Docker instead: docker run -p 8080:8080 conductoross/conductor:latest")
 		if err := downloadJar(jarPath, jarURL); err != nil {
 			return fmt.Errorf("failed to download server: %w", err)
 		}


### PR DESCRIPTION
## Summary

- Prints a "first run" heads-up message before the JAR download begins
- Surfaces the Docker alternative for users who want a faster first-run path

(Recreated from #80, which auto-closed when its stacked base (#79) merged.)

## User impact

First-time users who ran \`conductor server start\` would see a download progress bar appear with no warning about size or duration. On slow connections this could take 10+ minutes while the README promises "Get Running in 60 seconds." Now they get an explicit heads-up with an escape hatch (Docker) before the download begins.

Fixes conductor-oss/getting-started#3