### PR TITLE
fix: workflow status and signal commands on OSS Conductor

### DIFF
--- a/cmd/task.go
+++ b/cmd/task.go
@@ -411,6 +411,18 @@ func updateTaskByRefName(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// signalUnsupportedOnOSS returns an error when signal operations are invoked
+// against an OSS server. OSS Conductor does not implement the signal endpoints
+// (POST /tasks/{workflowId}/{status}/signal[/sync]); calling them there causes
+// the server to misinterpret the "signal" path segment as a TaskResult.Status,
+// producing a confusing type-conversion error. Signal is Enterprise-only.
+func signalUnsupportedOnOSS() error {
+	if !isEnterpriseServer() {
+		return fmt.Errorf("task signal is not supported in OSS Conductor; signal operations are only available in Orkes Conductor (Enterprise)")
+	}
+	return nil
+}
+
 func signalTaskAsync(cmd *cobra.Command, args []string) error {
 	workflowId, _ := cmd.Flags().GetString("workflow-id")
 	status, _ := cmd.Flags().GetString("status")
@@ -418,6 +430,10 @@ func signalTaskAsync(cmd *cobra.Command, args []string) error {
 
 	if workflowId == "" || status == "" {
 		return fmt.Errorf("--workflow-id and --status are required")
+	}
+
+	if err := signalUnsupportedOnOSS(); err != nil {
+		return err
 	}
 
 	var outputMap map[string]interface{}
@@ -447,6 +463,10 @@ func signalTaskSync(cmd *cobra.Command, args []string) error {
 
 	if workflowId == "" || status == "" {
 		return fmt.Errorf("--workflow-id and --status are required")
+	}
+
+	if err := signalUnsupportedOnOSS(); err != nil {
+		return err
 	}
 
 	var outputMap map[string]interface{}

--- a/cmd/task_test.go
+++ b/cmd/task_test.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSignalUnsupportedOnOSS(t *testing.T) {
+	// Case-insensitivity of serverType is the contract of isEnterpriseServer
+	// and is covered by TestIsEnterpriseServer. Here we only assert the two
+	// behaviors this function owns: error on non-Enterprise, nil on Enterprise.
+	tests := []struct {
+		name      string
+		serverVal string
+		wantErr   bool
+	}{
+		{name: "OSS returns error", serverVal: "OSS", wantErr: true},
+		{name: "Enterprise returns nil", serverVal: "Enterprise", wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldServerType := serverType
+			defer func() { serverType = oldServerType }()
+			serverType = tt.serverVal
+
+			err := signalUnsupportedOnOSS()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("signalUnsupportedOnOSS() with serverType=%q = nil, want error", tt.serverVal)
+				}
+				if !strings.Contains(err.Error(), "not supported in OSS Conductor") {
+					t.Errorf("error %q does not mention OSS Conductor", err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("signalUnsupportedOnOSS() with serverType=%q = %v, want nil", tt.serverVal, err)
+			}
+		})
+	}
+}

--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -952,13 +952,40 @@ func getWorkflowExecutionStatus(cmd *cobra.Command, args []string) error {
 
 	for i := 0; i < len(args); i++ {
 		id := args[i]
-		status, _, getStateErr := workflowClient.GetWorkflowState(context.Background(), id, true, true)
-		if getStateErr != nil {
-			return parseAPIError(getStateErr, fmt.Sprintf("Failed to get workflow status for '%s'", id))
+		status, err := resolveWorkflowStatus(workflowClient, id)
+		if err != nil {
+			return err
 		}
-		fmt.Println(status.Status)
+		fmt.Println(status)
 	}
 	return nil
+}
+
+// resolveWorkflowStatus returns the status of a workflow execution.
+//
+// It first tries GetWorkflowState (GET /workflow/{id}/status), the cheap
+// purpose-built endpoint available on Orkes Conductor. OSS Conductor does not
+// implement that route and returns 404, so on a 404 we fall back to fetching
+// the full workflow (GET /workflow/{id}), which is available on all server
+// versions and carries the same status value. Gating on the 404 response —
+// rather than serverType — keeps this working even when serverType is
+// misconfigured, and automatically uses the fast path once OSS adds /status.
+func resolveWorkflowStatus(workflowClient *client.WorkflowResourceApiService, id string) (string, error) {
+	state, resp, getStateErr := workflowClient.GetWorkflowState(context.Background(), id, true, true)
+	if getStateErr == nil {
+		return state.Status, nil
+	}
+
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		opts := &client.WorkflowResourceApiGetExecutionStatusOpts{IncludeTasks: optional.NewBool(false)}
+		workflow, _, execErr := workflowClient.GetExecutionStatus(context.Background(), id, opts)
+		if execErr != nil {
+			return "", parseAPIError(execErr, fmt.Sprintf("Failed to get workflow status for '%s'", id))
+		}
+		return string(workflow.Status), nil
+	}
+
+	return "", parseAPIError(getStateErr, fmt.Sprintf("Failed to get workflow status for '%s'", id))
 }
 
 func getWorkflowExecution(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## What changed

Two commands failed against OSS Conductor because OSS and Orkes expose different REST APIs:

- **`workflow status`** — was calling `GET /workflow/{id}/status` (`GetWorkflowState`), a route OSS doesn't implement → 404. Now it tries that endpoint first and, **on a 404**, falls back to the full-workflow endpoint `GET /workflow/{id}` (`GetExecutionStatus`) and prints its `Status`. Output is identical on both server types.
- **`task signal` / `task signal-sync`** — hit `POST /tasks/{id}/{status}/signal[/sync]`, which don't exist in OSS; the server misparsed `signal` as a status enum and returned a Java type-conversion error. They now fail fast on OSS with a clear "not supported in OSS Conductor" message (exit 1).

Fixes conductor-oss/conductor#1197

## Why this approach

- **Status gates on the 404 response, not `serverType`.** This stays correct even if `serverType` is misconfigured/unset, and automatically uses the cheaper `/status` endpoint once a future OSS version adds it — no CLI change needed. The SDK returns a non-nil `*http.Response` on non-2xx, so `resp.StatusCode == 404` is a reliable branch point.
- **Signal gates on `serverType`** because OSS returns a confusing type-conversion error rather than a clean 404 — there's nothing useful to fall back to. Matches the existing `webhook_metadata.go` "Not supported in OSS Conductor" convention.

Server-side work (adding `/status` to OSS) is intentionally out of scope; the fallback already covers existing OSS versions.

## How to test

- `go test ./...` passes; new unit test `TestSignalUnsupportedOnOSS` covers the signal gate across server types.
- Manual: start a local OSS server (`conductor server`), start a workflow, then `conductor workflow status <id>` prints the status (previously 404); `conductor task signal --workflow-id <id> --status COMPLETED` returns the not-supported message.

## Review notes

- Status logic extracted into `resolveWorkflowStatus` to keep the multi-arg loop readable.
- The status fallback path itself isn't unit-tested (depends on live SDK HTTP calls; `internal.GetWorkflowClient()` isn't injectable) — verified manually instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)