### PR TITLE
Combine agentspan cli to conductor

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -1,0 +1,508 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/conductor-oss/conductor-cli/internal"
+	"github.com/conductor-oss/conductor-cli/internal/agent"
+)
+
+// Defaults that are policy, not server contract — named so they are not magic
+// literals scattered through the code.
+const (
+	defaultExecutionSearchSize = 50
+	defaultPruneOlderThanDays  = 30
+	defaultInitModel           = "openai/gpt-4o"
+	defaultInitMaxTurns        = 25
+)
+
+var agentCmd = &cobra.Command{
+	Use:     "agent",
+	Aliases: []string{"a"},
+	Short:   "Manage and run agents",
+	GroupID: "conductor",
+}
+
+// ---- agent list ----
+
+var agentListCmd = &cobra.Command{
+	Use:          "list",
+	Short:        "List registered agents",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		format, err := GetOutputFormat(cmd)
+		if err != nil {
+			return err
+		}
+		agents, err := internal.GetAgentService().List(cmd.Context())
+		if err != nil {
+			return err
+		}
+		return renderAgentList(agents, format)
+	},
+}
+
+func renderAgentList(agents []agent.AgentSummary, format OutputFormat) error {
+	switch format {
+	case OutputFormatJSON:
+		data, err := json.MarshalIndent(agents, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+	case OutputFormatCSV:
+		w := NewCSVWriter()
+		w.WriteHeader("NAME", "VERSION", "TYPE", "DESCRIPTION")
+		for _, a := range agents {
+			w.WriteRow(a.Name, strconv.Itoa(a.Version), a.Type, a.Description)
+		}
+		w.Flush()
+	default:
+		if len(agents) == 0 {
+			fmt.Println("No agents found.")
+			return nil
+		}
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		fmt.Fprintln(w, "NAME\tVERSION\tTYPE\tDESCRIPTION")
+		for _, a := range agents {
+			fmt.Fprintf(w, "%s\t%d\t%s\t%s\n", a.Name, a.Version, a.Type, a.Description)
+		}
+		w.Flush()
+	}
+	return nil
+}
+
+// ---- agent get ----
+
+var agentGetVersion int
+
+var agentGetCmd = &cobra.Command{
+	Use:          "get <name>",
+	Short:        "Get an agent definition",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		def, err := internal.GetAgentService().Get(cmd.Context(), args[0], optionalVersion(cmd, agentGetVersion))
+		if err != nil {
+			return err
+		}
+		return printRawJSON(def)
+	},
+}
+
+// ---- agent delete ----
+
+var agentDeleteVersion int
+
+var agentDeleteCmd = &cobra.Command{
+	Use:          "delete <name>",
+	Short:        "Delete an agent definition",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if !confirmDeletion("agent", args[0]) {
+			fmt.Println("Aborted.")
+			return nil
+		}
+		if err := internal.GetAgentService().Delete(cmd.Context(), args[0], optionalVersion(cmd, agentDeleteVersion)); err != nil {
+			return err
+		}
+		fmt.Printf("Deleted agent '%s'.\n", args[0])
+		return nil
+	},
+}
+
+// ---- agent compile ----
+
+var agentCompileCmd = &cobra.Command{
+	Use:          "compile <config-file>",
+	Short:        "Compile an agent config and show its execution plan",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		def, err := loadAgentConfig(args[0])
+		if err != nil {
+			return err
+		}
+		plan, err := internal.GetAgentService().Compile(cmd.Context(), def)
+		if err != nil {
+			return err
+		}
+		return printRawJSON(plan)
+	},
+}
+
+// ---- agent execution (search history) ----
+
+var (
+	execName   string
+	execStatus string
+	execSince  string
+	execWindow string
+)
+
+var agentExecutionCmd = &cobra.Command{
+	Use:   "execution",
+	Short: "Search agent execution history",
+	Long: `Search agent execution history with optional filters.
+
+Time formats for --since and --window: 30s, 5m, 1h, 6h, 1d, 7d, 1mo, 1y`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		format, err := GetOutputFormat(cmd)
+		if err != nil {
+			return err
+		}
+		freeText, err := buildExecutionFreeText(execSince, execWindow)
+		if err != nil {
+			return err
+		}
+		page, err := internal.GetAgentService().SearchExecutions(cmd.Context(), agent.ExecutionFilter{
+			AgentName: execName,
+			Status:    execStatus,
+			FreeText:  freeText,
+			Start:     0,
+			Size:      defaultExecutionSearchSize,
+		})
+		if err != nil {
+			return err
+		}
+		return renderExecutionPage(page, format)
+	},
+}
+
+func renderExecutionPage(page agent.ExecutionPage, format OutputFormat) error {
+	switch format {
+	case OutputFormatJSON:
+		data, err := json.MarshalIndent(page, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+	case OutputFormatCSV:
+		w := NewCSVWriter()
+		w.WriteHeader("ID", "AGENT", "STATUS", "START_TIME", "DURATION")
+		for _, e := range page.Results {
+			w.WriteRow(e.ExecutionID, e.AgentName, e.Status, truncateTimestamp(e.StartTime), formatMillis(e.ExecutionTime))
+		}
+		w.Flush()
+	default:
+		if len(page.Results) == 0 {
+			fmt.Println("No executions found.")
+			return nil
+		}
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		fmt.Fprintln(w, "ID\tAGENT\tSTATUS\tSTART TIME\tDURATION")
+		for _, e := range page.Results {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+				e.ExecutionID, e.AgentName, e.Status, truncateTimestamp(e.StartTime), formatMillis(e.ExecutionTime))
+		}
+		w.Flush()
+		fmt.Printf("\n%d of %d execution(s).\n", len(page.Results), page.TotalHits)
+	}
+	return nil
+}
+
+// ---- agent status ----
+
+var agentStatusCmd = &cobra.Command{
+	Use:          "status <execution-id>",
+	Short:        "Get detailed status of an execution",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		detail, err := internal.GetAgentService().Status(cmd.Context(), args[0])
+		if err != nil {
+			return err
+		}
+		return printRawJSON(detail)
+	},
+}
+
+// ---- agent respond (human-in-the-loop) ----
+
+var (
+	respondApprove bool
+	respondDeny    bool
+	respondReason  string
+	respondMessage string
+)
+
+var agentRespondCmd = &cobra.Command{
+	Use:          "respond <execution-id>",
+	Short:        "Respond to a human-in-the-loop task",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if !respondApprove && !respondDeny {
+			return fmt.Errorf("specify --approve or --deny")
+		}
+		if err := internal.GetAgentService().Respond(cmd.Context(), args[0], agent.HumanResponse{
+			Approved: respondApprove,
+			Reason:   respondReason,
+			Message:  respondMessage,
+		}); err != nil {
+			return err
+		}
+		fmt.Printf("Response sent for execution '%s'.\n", args[0])
+		return nil
+	},
+}
+
+// ---- agent prune ----
+
+var (
+	pruneOlderThan int
+	pruneArchive   bool
+	pruneDryRun    bool
+)
+
+var agentPruneCmd = &cobra.Command{
+	Use:          "prune",
+	Short:        "Delete (or archive) old execution records",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if pruneDryRun {
+			fmt.Printf("Dry run: would prune executions older than %d day(s) (archive=%t).\n", pruneOlderThan, pruneArchive)
+			return nil
+		}
+		res, err := internal.GetAgentService().Prune(cmd.Context(), agent.PruneRequest{
+			OlderThanDays: pruneOlderThan,
+			Archive:       pruneArchive,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Pruned %d execution record(s).\n", res.Removed)
+		return nil
+	},
+}
+
+// ---- agent init (local scaffolding; no server) ----
+
+var (
+	initModel    string
+	initStrategy string
+	initFormat   string
+)
+
+var agentInitCmd = &cobra.Command{
+	Use:          "init <agent-name>",
+	Short:        "Create a starter agent config file",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := args[0]
+		model := initModel
+		if model == "" {
+			model = defaultInitModel
+		}
+		cfg := map[string]any{
+			"name":         name,
+			"description":  fmt.Sprintf("%s agent", name),
+			"model":        model,
+			"instructions": fmt.Sprintf("You are %s, a helpful AI assistant.", name),
+			"maxTurns":     defaultInitMaxTurns,
+			"tools":        []any{},
+		}
+		if initStrategy != "" {
+			cfg["strategy"] = initStrategy
+		}
+
+		var data []byte
+		var err error
+		ext := "yaml"
+		if initFormat == "json" {
+			ext = "json"
+			data, err = json.MarshalIndent(cfg, "", "  ")
+		} else {
+			data, err = yaml.Marshal(cfg)
+		}
+		if err != nil {
+			return err
+		}
+
+		filename := fmt.Sprintf("%s.%s", name, ext)
+		if err := os.WriteFile(filename, data, 0o644); err != nil {
+			return fmt.Errorf("write file: %w", err)
+		}
+		fmt.Printf("Created %s\n", filename)
+		fmt.Printf("Run with: conductor agent run --config %s \"your prompt here\"\n", filename)
+		return nil
+	},
+}
+
+// ---- helpers (file I/O and formatting live here, in the cmd layer) ----
+
+// loadAgentConfig reads a YAML or JSON agent config from disk and returns it as
+// JSON bytes. File access stays in the cmd layer; the service/client only ever see
+// parsed bytes — no path crosses a layer boundary.
+func loadAgentConfig(path string) (json.RawMessage, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read config file: %w", err)
+	}
+	var cfg map[string]any
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			return nil, fmt.Errorf("parse config file (tried YAML and JSON): %w", err)
+		}
+	}
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("encode config: %w", err)
+	}
+	return raw, nil
+}
+
+// printRawJSON pretty-prints raw server JSON, falling back to the raw bytes when the
+// payload is not indentable.
+func printRawJSON(raw json.RawMessage) error {
+	var buf bytes.Buffer
+	if err := json.Indent(&buf, raw, "", "  "); err != nil {
+		fmt.Println(string(raw))
+		return nil
+	}
+	fmt.Println(buf.String())
+	return nil
+}
+
+// optionalVersion returns a pointer to v only when the version flag was set.
+func optionalVersion(cmd *cobra.Command, v int) *int {
+	if cmd.Flags().Changed("version") {
+		return &v
+	}
+	return nil
+}
+
+func truncateTimestamp(ts string) string {
+	const secondsPrecision = 19 // YYYY-MM-DDТHH:MM:SS
+	if len(ts) > secondsPrecision {
+		return ts[:secondsPrecision]
+	}
+	return ts
+}
+
+func formatMillis(ms int64) string {
+	if ms <= 0 {
+		return "-"
+	}
+	return (time.Duration(ms) * time.Millisecond).String()
+}
+
+// buildExecutionFreeText converts the --since / --window flags into the server's
+// freeText time-range query.
+func buildExecutionFreeText(since, window string) (string, error) {
+	freeText := ""
+	if since != "" {
+		dur, err := parseTimeSpec(since)
+		if err != nil {
+			return "", fmt.Errorf("invalid --since value: %w", err)
+		}
+		start := time.Now().Add(-dur).UnixMilli()
+		freeText = fmt.Sprintf("startTime:[%d TO *]", start)
+	}
+	if window != "" {
+		spec := window
+		const relativePrefix = "now-"
+		if len(spec) > len(relativePrefix) && spec[:len(relativePrefix)] == relativePrefix {
+			spec = spec[len(relativePrefix):]
+		}
+		dur, err := parseTimeSpec(spec)
+		if err != nil {
+			return "", fmt.Errorf("invalid --window value: %w", err)
+		}
+		end := time.Now().UnixMilli()
+		start := time.Now().Add(-dur).UnixMilli()
+		q := fmt.Sprintf("startTime:[%d TO %d]", start, end)
+		if freeText != "" {
+			freeText += " AND " + q
+		} else {
+			freeText = q
+		}
+	}
+	return freeText, nil
+}
+
+var timeSpecPattern = regexp.MustCompile(`^(\d+)(s|m|h|d|mo|y)$`)
+
+// parseTimeSpec parses durations like 30s, 5m, 1h, 1d, 1mo, 1y.
+func parseTimeSpec(s string) (time.Duration, error) {
+	m := timeSpecPattern.FindStringSubmatch(s)
+	if m == nil {
+		return 0, fmt.Errorf("expected format like 30s, 5m, 1h, 1d, 1mo, 1y; got %q", s)
+	}
+	n, _ := strconv.Atoi(m[1])
+	unit := map[string]time.Duration{
+		"s":  time.Second,
+		"m":  time.Minute,
+		"h":  time.Hour,
+		"d":  24 * time.Hour,
+		"mo": 30 * 24 * time.Hour,
+		"y":  365 * 24 * time.Hour,
+	}[m[2]]
+	return time.Duration(n) * unit, nil
+}
+
+func init() {
+	agentGetCmd.Flags().IntVar(&agentGetVersion, "version", 0, "Agent version (default: latest)")
+	agentDeleteCmd.Flags().IntVar(&agentDeleteVersion, "version", 0, "Agent version (default: latest)")
+
+	AddOutputFlags(agentListCmd)
+
+	agentExecutionCmd.Flags().StringVar(&execName, "name", "", "Filter by agent name")
+	agentExecutionCmd.Flags().StringVar(&execStatus, "status", "", "Filter by status (RUNNING, COMPLETED, FAILED, ...)")
+	agentExecutionCmd.Flags().StringVar(&execSince, "since", "", "Show executions since (e.g. 30m, 1h, 1d)")
+	agentExecutionCmd.Flags().StringVar(&execWindow, "window", "", "Time window (e.g. now-1h, now-7d)")
+	AddOutputFlags(agentExecutionCmd)
+
+	agentRespondCmd.Flags().BoolVar(&respondApprove, "approve", false, "Approve the pending action")
+	agentRespondCmd.Flags().BoolVar(&respondDeny, "deny", false, "Deny the pending action")
+	agentRespondCmd.Flags().StringVar(&respondReason, "reason", "", "Reason for the decision")
+	agentRespondCmd.Flags().StringVarP(&respondMessage, "message", "m", "", "Free-form message")
+	agentRespondCmd.MarkFlagsMutuallyExclusive("approve", "deny")
+
+	agentPruneCmd.Flags().IntVar(&pruneOlderThan, "older-than", defaultPruneOlderThanDays, "Delete executions older than N days")
+	agentPruneCmd.Flags().BoolVar(&pruneArchive, "archive", false, "Archive tasks instead of hard-deleting")
+	agentPruneCmd.Flags().BoolVar(&pruneDryRun, "dry-run", false, "Show what would be pruned without deleting")
+
+	agentInitCmd.Flags().StringVarP(&initModel, "model", "", "", "LLM model (default: "+defaultInitModel+")")
+	agentInitCmd.Flags().StringVarP(&initStrategy, "strategy", "s", "", "Multi-agent strategy (handoff, sequential, parallel, ...)")
+	agentInitCmd.Flags().StringVarP(&initFormat, "format", "f", "yaml", "Output format: yaml or json")
+
+	agentCmd.AddCommand(
+		agentListCmd,
+		agentGetCmd,
+		agentDeleteCmd,
+		agentCompileCmd,
+		agentExecutionCmd,
+		agentStatusCmd,
+		agentRespondCmd,
+		agentPruneCmd,
+		agentInitCmd,
+	)
+	rootCmd.AddCommand(agentCmd)
+}

--- a/cmd/agent_stream.go
+++ b/cmd/agent_stream.go
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/conductor-oss/conductor-cli/internal"
+	"github.com/conductor-oss/conductor-cli/internal/agent"
+)
+
+// Display truncation widths for streamed events — named so they are not magic
+// literals at the call sites.
+const (
+	truncThinking   = 120
+	truncToolInput  = 100
+	truncToolResult = 200
+	truncEventData  = 150
+)
+
+var (
+	runName     string
+	runConfig   string
+	runSession  string
+	runNoStream bool
+)
+
+var agentRunCmd = &cobra.Command{
+	Use:   "run [prompt]",
+	Short: "Start an agent and stream its output",
+	Long: `Start an agent by --name or --config with a prompt and stream its execution
+events in real time. Use --no-stream to start it and just print the execution id.`,
+	Args:         cobra.MinimumNArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		prompt := strings.Join(args, " ")
+		svc := internal.GetAgentService()
+
+		var req agent.RunRequest
+		switch {
+		case runConfig != "":
+			def, err := loadAgentConfig(runConfig)
+			if err != nil {
+				return err
+			}
+			req = agent.RunRequest{Definition: def, Prompt: prompt, SessionID: runSession}
+		case runName != "":
+			req = agent.RunRequest{Name: runName, Prompt: prompt, SessionID: runSession}
+		default:
+			return fmt.Errorf("specify either --name or --config")
+		}
+
+		exec, err := svc.Run(cmd.Context(), req)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Agent: %s (Execution: %s)\n", exec.AgentName, exec.ID)
+		if runNoStream {
+			return nil
+		}
+
+		fmt.Println()
+		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt)
+		defer stop()
+		return svc.StreamExecution(ctx, exec.ID, "", terminalSink{})
+	},
+}
+
+var streamLastEventID string
+
+var agentStreamCmd = &cobra.Command{
+	Use:          "stream <execution-id>",
+	Short:        "Stream events from a running execution",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt)
+		defer stop()
+		return internal.GetAgentService().StreamExecution(ctx, args[0], streamLastEventID, terminalSink{})
+	},
+}
+
+// terminalSink renders streamed agent events to stdout. It is the cmd-layer
+// presentation of agent.EventSink; the service and client know nothing about it.
+type terminalSink struct{}
+
+func (terminalSink) OnEvent(e agent.SSEEvent) error {
+	data := map[string]any{}
+	_ = json.Unmarshal(e.Data, &data)
+
+	switch e.ResolvedType() {
+	case agent.EventThinking:
+		fmt.Printf("  [thinking] %s\n", truncate(mapStr(data, "message"), truncThinking))
+	case agent.EventToolCall:
+		fmt.Printf("  [tool] %s(%s)\n", mapStr(data, "toolName"), truncate(mapStr(data, "input"), truncToolInput))
+	case agent.EventToolResult:
+		fmt.Printf("  [result] %s -> %s\n", mapStr(data, "toolName"), truncate(mapStr(data, "result"), truncToolResult))
+	case agent.EventHandoff:
+		fmt.Printf("  [handoff] -> %s\n", mapStr(data, "agentName"))
+	case agent.EventMessage:
+		if content := mapStr(data, "content"); content != "" {
+			fmt.Print(content)
+		}
+	case agent.EventWaiting:
+		fmt.Printf("  [waiting] human input required (execution: %s)\n", mapStr(data, "executionId"))
+	case agent.EventGuardrailPass:
+		fmt.Printf("  [guardrail] PASS %s\n", mapStr(data, "guardrailName"))
+	case agent.EventGuardrailFail:
+		fmt.Printf("  [guardrail] FAIL %s: %s\n", mapStr(data, "guardrailName"), mapStr(data, "reason"))
+	case agent.EventError:
+		fmt.Printf("  [error] %s\n", mapStr(data, "message"))
+	case agent.EventDone:
+		if out := mapStr(data, "output"); out != "" {
+			fmt.Println()
+			fmt.Println(out)
+		}
+	default:
+		if t := e.ResolvedType(); t != "" {
+			fmt.Printf("  [%s] %s\n", t, truncate(string(e.Data), truncEventData))
+		}
+	}
+	return nil
+}
+
+// mapStr returns a string field from a decoded event payload, JSON-encoding non-string values.
+func mapStr(data map[string]any, key string) string {
+	v, ok := data[key]
+	if !ok {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	b, _ := json.Marshal(v)
+	return string(b)
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}
+
+func init() {
+	agentRunCmd.Flags().StringVar(&runName, "name", "", "Name of a registered agent to run")
+	agentRunCmd.Flags().StringVar(&runConfig, "config", "", "Path to an agent config file (YAML/JSON)")
+	agentRunCmd.Flags().StringVar(&runSession, "session", "", "Session id for conversation continuity")
+	agentRunCmd.Flags().BoolVar(&runNoStream, "no-stream", false, "Start the agent and print the execution id without streaming")
+
+	agentStreamCmd.Flags().StringVar(&streamLastEventID, "last-event-id", "", "Resume streaming after this event id")
+
+	agentCmd.AddCommand(agentRunCmd, agentStreamCmd)
+}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -117,6 +117,9 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 	}
+	if err := internal.GetAgentService().CheckSupported(ctx); err != nil {
+		return err
+	}
 
 	names := make([]string, len(discovered))
 	for i, a := range discovered {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -1,0 +1,477 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/conductor-oss/conductor-cli/internal"
+	"github.com/conductor-oss/conductor-cli/internal/deploy"
+)
+
+const (
+	langPython     = "python"
+	langTypeScript = "typescript"
+)
+
+// discoveredAgent is one agent reported by the discover subprocess.
+type discoveredAgent struct {
+	Name      string `json:"name"`
+	Framework string `json:"framework"`
+}
+
+// deployResult is the outcome of deploying one agent, as reported by the subprocess.
+type deployResult struct {
+	AgentName      string  `json:"agent_name"`
+	RegisteredName *string `json:"registered_name"`
+	Success        bool    `json:"success"`
+	Error          *string `json:"error"`
+}
+
+var (
+	deployAgents   []string
+	deployLanguage string
+	deployPackage  string
+	deployJSON     bool
+)
+
+var deployCmd = &cobra.Command{
+	Use:          "deploy",
+	Short:        "Deploy agents from your project to the Conductor server",
+	GroupID:      "development",
+	SilenceUsage: true,
+	RunE:         runDeploy,
+}
+
+func runDeploy(cmd *cobra.Command, args []string) error {
+	wd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("get working directory: %w", err)
+	}
+
+	agentNames := cleanNames(deployAgents)
+
+	language, err := detectLanguage(wd, deployLanguage)
+	if err != nil {
+		return err
+	}
+
+	pythonBin := ""
+	if language == langPython {
+		if pythonBin = findPythonBinary(wd); pythonBin == "" {
+			return fmt.Errorf("no Python interpreter found; install Python or set the PYTHON environment variable")
+		}
+	}
+
+	pkg, err := inferPackage(wd, language, deployPackage)
+	if err != nil {
+		return err
+	}
+
+	ctx := cmd.Context()
+	t := internal.Transport()
+	env, err := deploy.EnvBuilder{BaseURL: t.BaseURL, Tokens: t.Tokens, BaseEnv: os.Environ()}.Build(ctx)
+	if err != nil {
+		return err
+	}
+	runner := deploy.NewRunner()
+
+	discovered, err := execDiscover(ctx, runner, env, language, pythonBin, wd, pkg)
+	if err != nil {
+		return err
+	}
+	if len(discovered) == 0 {
+		return fmt.Errorf("no agents found in %q; define agents as module-level variables, or use --package/--path", pkg.Value)
+	}
+	allDiscovered := discovered
+
+	if discovered, err = filterDiscoveredAgents(discovered, agentNames); err != nil {
+		return err
+	}
+
+	if !deployJSON {
+		fmt.Println(formatDiscoveryTable(discovered, pkg.Value))
+		if !yes && !confirm("Deploy these agents?") {
+			fmt.Println("Aborted.")
+			return nil
+		}
+	}
+
+	names := make([]string, len(discovered))
+	for i, a := range discovered {
+		names[i] = a.Name
+	}
+
+	results, err := execDeploy(ctx, runner, env, language, pythonBin, wd, pkg, names)
+	if err != nil {
+		return err
+	}
+
+	failed := 0
+	for _, r := range results {
+		if !r.Success {
+			failed++
+		}
+	}
+
+	if deployJSON {
+		out := map[string]any{
+			"discovered": allDiscovered,
+			"deployed":   results,
+			"summary":    map[string]int{"total": len(results), "succeeded": len(results) - failed, "failed": failed},
+		}
+		data, mErr := json.MarshalIndent(out, "", "  ")
+		if mErr != nil {
+			return mErr
+		}
+		fmt.Println(string(data))
+	} else {
+		fmt.Println(formatDeployOutput(results))
+	}
+
+	if failed > 0 {
+		return fmt.Errorf("%d agent(s) failed to deploy", failed)
+	}
+	return nil
+}
+
+func cleanNames(names []string) []string {
+	out := names[:0]
+	for _, n := range names {
+		if n = strings.TrimSpace(n); n != "" {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+func confirm(prompt string) bool {
+	fmt.Printf("%s [y/N] ", prompt)
+	var answer string
+	fmt.Scanln(&answer)
+	answer = strings.ToLower(strings.TrimSpace(answer))
+	return answer == "y" || answer == "yes"
+}
+
+// detectLanguage resolves the project language from --language or marker files.
+func detectLanguage(dir, override string) (string, error) {
+	if override != "" {
+		switch strings.ToLower(override) {
+		case "python", "py":
+			return langPython, nil
+		case "typescript", "ts":
+			return langTypeScript, nil
+		default:
+			return "", fmt.Errorf("unsupported language %q (supported: python, typescript)", override)
+		}
+	}
+
+	hasPython := false
+	for _, m := range []string{"pyproject.toml", "setup.py", "setup.cfg", "requirements.txt"} {
+		if _, err := os.Stat(filepath.Join(dir, m)); err == nil {
+			hasPython = true
+			break
+		}
+	}
+	hasTS := false
+	if _, err := os.Stat(filepath.Join(dir, "tsconfig.json")); err == nil {
+		hasTS = true
+	} else if hasTSDependency(filepath.Join(dir, "package.json")) {
+		hasTS = true
+	}
+
+	switch {
+	case hasPython && hasTS:
+		return "", fmt.Errorf("both Python and TypeScript markers found; use --language to disambiguate")
+	case hasPython:
+		return langPython, nil
+	case hasTS:
+		return langTypeScript, nil
+	default:
+		return "", fmt.Errorf("no Python or TypeScript project markers found; use --language to specify")
+	}
+}
+
+func hasTSDependency(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	var pkg map[string]any
+	if json.Unmarshal(data, &pkg) != nil {
+		return false
+	}
+	for _, section := range []string{"dependencies", "devDependencies"} {
+		deps, ok := pkg[section].(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, dep := range []string{"typescript", "tsx", "ts-node"} {
+			if _, found := deps[dep]; found {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// packageInfo is the inferred package/path and how to pass it to the subprocess.
+type packageInfo struct {
+	Value  string
+	IsPath bool // true => --path, false => --package
+}
+
+func inferPackage(dir, language, override string) (packageInfo, error) {
+	if override != "" {
+		isPath := strings.Contains(override, "/") || strings.HasPrefix(override, ".")
+		return packageInfo{Value: override, IsPath: isPath}, nil
+	}
+	switch language {
+	case langPython:
+		if pkg, err := inferPythonPackage(dir); err == nil {
+			return packageInfo{Value: pkg, IsPath: false}, nil
+		}
+		return packageInfo{Value: dir, IsPath: true}, nil
+	case langTypeScript:
+		if info, err := os.Stat(filepath.Join(dir, "src")); err == nil && info.IsDir() {
+			return packageInfo{Value: "./src", IsPath: true}, nil
+		}
+		return packageInfo{Value: ".", IsPath: true}, nil
+	default:
+		return packageInfo{}, fmt.Errorf("cannot infer package for language %q", language)
+	}
+}
+
+func inferPythonPackage(dir string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(dir, "pyproject.toml"))
+	if err != nil {
+		return "", fmt.Errorf("pyproject.toml not found; use --package")
+	}
+	name := parsePyprojectName(string(data))
+	if name == "" {
+		return "", fmt.Errorf("no [project] name in pyproject.toml; use --package")
+	}
+	return strings.ReplaceAll(name, "-", "_"), nil // PEP 503 import name
+}
+
+// parsePyprojectName extracts name from the [project] table without a TOML dependency.
+func parsePyprojectName(content string) string {
+	inProject := false
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case trimmed == "[project]":
+			inProject = true
+		case inProject && strings.HasPrefix(trimmed, "["):
+			return ""
+		case inProject && strings.HasPrefix(trimmed, "name"):
+			if parts := strings.SplitN(trimmed, "=", 2); len(parts) == 2 {
+				return strings.Trim(strings.TrimSpace(parts[1]), `"'`)
+			}
+		}
+	}
+	return ""
+}
+
+func findPythonBinary(dir string) string {
+	if p := os.Getenv("PYTHON"); p != "" {
+		return p
+	}
+	for _, venv := range []string{".venv", "venv"} {
+		candidate := filepath.Join(dir, venv, "bin", "python")
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+	for _, name := range []string{"python3", "python"} {
+		if p, err := exec.LookPath(name); err == nil {
+			return p
+		}
+	}
+	return ""
+}
+
+func execDiscover(ctx context.Context, runner deploy.Runner, env []string, language, pythonBin, projectDir string, pkg packageInfo) ([]discoveredAgent, error) {
+	data, err := runLanguageTool(ctx, runner, env, language, pythonBin, projectDir, pkg, "discover", "agentspan.cli.discover", "discover.ts", nil)
+	if err != nil && len(data) == 0 {
+		return nil, err
+	}
+	var agents []discoveredAgent
+	if uErr := json.Unmarshal(data, &agents); uErr != nil {
+		return nil, fmt.Errorf("parse discovery result: %w", uErr)
+	}
+	return agents, nil
+}
+
+func execDeploy(ctx context.Context, runner deploy.Runner, env []string, language, pythonBin, projectDir string, pkg packageInfo, agentNames []string) ([]deployResult, error) {
+	data, err := runLanguageTool(ctx, runner, env, language, pythonBin, projectDir, pkg, "deploy", "agentspan.cli.deploy", "deploy.ts", agentNames)
+	if err != nil && len(data) == 0 {
+		return nil, err
+	}
+	var results []deployResult
+	if uErr := json.Unmarshal(data, &results); uErr != nil {
+		return nil, fmt.Errorf("parse deploy result: %w", uErr)
+	}
+	return results, nil
+}
+
+// runLanguageTool invokes the python module or the TypeScript bin script for an
+// operation, passing the package/path and optional agent names.
+func runLanguageTool(ctx context.Context, runner deploy.Runner, env []string, language, pythonBin, projectDir string, pkg packageInfo, op, pyModule, tsScript string, agentNames []string) ([]byte, error) {
+	switch language {
+	case langPython:
+		flag := "--package"
+		if pkg.IsPath {
+			flag = "--path"
+		}
+		args := []string{"-m", pyModule, flag, pkg.Value}
+		args = appendAgents(args, agentNames)
+		return runner.Run(ctx, env, pythonBin, args...)
+	case langTypeScript:
+		script, err := findTSBinScript(projectDir, tsScript)
+		if err != nil {
+			return nil, err
+		}
+		args := []string{"tsx", script, "--path", pkg.Value}
+		args = appendAgents(args, agentNames)
+		return runner.Run(ctx, env, "npx", args...)
+	default:
+		return nil, fmt.Errorf("unsupported language for %s: %s", op, language)
+	}
+}
+
+func appendAgents(args, agentNames []string) []string {
+	if len(agentNames) > 0 {
+		args = append(args, "--agents", strings.Join(agentNames, ","))
+	}
+	return args
+}
+
+func filterDiscoveredAgents(agents []discoveredAgent, names []string) ([]discoveredAgent, error) {
+	if len(names) == 0 {
+		return agents, nil
+	}
+	byName := make(map[string]discoveredAgent, len(agents))
+	for _, a := range agents {
+		byName[a.Name] = a
+	}
+	var notFound []string
+	var result []discoveredAgent
+	seen := map[string]bool{}
+	for _, n := range names {
+		if seen[n] {
+			continue
+		}
+		seen[n] = true
+		if a, ok := byName[n]; ok {
+			result = append(result, a)
+		} else {
+			notFound = append(notFound, n)
+		}
+	}
+	if len(notFound) > 0 {
+		available := make([]string, 0, len(agents))
+		for _, a := range agents {
+			available = append(available, a.Name)
+		}
+		return nil, fmt.Errorf("agent(s) not found: %s (available: %s)", strings.Join(notFound, ", "), strings.Join(available, ", "))
+	}
+	return result, nil
+}
+
+func findTSBinScript(dir, name string) (string, error) {
+	cur, _ := filepath.Abs(dir)
+	for {
+		for _, p := range []string{
+			filepath.Join(cur, "node_modules", "@agentspan", "sdk", "cli-bin", name),
+			filepath.Join(cur, "node_modules", "agentspan", "cli-bin", name),
+			filepath.Join(cur, "cli-bin", name),
+		} {
+			if _, err := os.Stat(p); err == nil {
+				return p, nil
+			}
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			return "", fmt.Errorf("cannot find %s under node_modules; install the AgentSpan SDK", name)
+		}
+		cur = parent
+	}
+}
+
+func formatDiscoveryTable(agents []discoveredAgent, pkg string) string {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "\nDiscovered %d agent(s) in %s:\n\n", len(agents), pkg)
+	w := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tFRAMEWORK")
+	for _, a := range agents {
+		fmt.Fprintf(w, "%s\t%s\n", a.Name, a.Framework)
+	}
+	w.Flush()
+	return buf.String()
+}
+
+func formatDeployOutput(results []deployResult) string {
+	var buf bytes.Buffer
+	succeeded, failed := 0, 0
+	fmt.Fprintln(&buf)
+	for _, r := range results {
+		if r.Success {
+			succeeded++
+			fmt.Fprintf(&buf, "  ok  %s", r.AgentName)
+			if r.RegisteredName != nil && *r.RegisteredName != "" && *r.RegisteredName != r.AgentName {
+				fmt.Fprintf(&buf, " (registered as %s)", *r.RegisteredName)
+			}
+			fmt.Fprintln(&buf)
+		} else {
+			failed++
+			msg := "unknown error"
+			if r.Error != nil {
+				msg = *r.Error
+			}
+			fmt.Fprintf(&buf, "  fail %s: %s\n", r.AgentName, msg)
+		}
+	}
+	fmt.Fprintln(&buf)
+	switch {
+	case failed == 0:
+		fmt.Fprintf(&buf, "All %d agent(s) deployed successfully.\n", succeeded)
+	case succeeded == 0:
+		fmt.Fprintf(&buf, "All %d agent(s) failed to deploy. Check 'conductor doctor'.\n", failed)
+	default:
+		fmt.Fprintf(&buf, "%d deployed, %d failed.\n", succeeded, failed)
+	}
+	if succeeded > 0 {
+		fmt.Fprintln(&buf, "\nRun with: conductor agent run --name <agent> \"your prompt\"")
+	}
+	return buf.String()
+}
+
+func init() {
+	deployCmd.Flags().StringSliceVarP(&deployAgents, "agents", "a", nil, "Comma-separated agent names to deploy (default: all)")
+	deployCmd.Flags().StringVarP(&deployLanguage, "language", "l", "", "Project language: python or typescript")
+	deployCmd.Flags().StringVarP(&deployPackage, "package", "p", "", "Package or path to scan for agents")
+	deployCmd.Flags().BoolVar(&deployJSON, "json", false, "Output results as JSON")
+	rootCmd.AddCommand(deployCmd)
+}

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/conductor-oss/conductor-cli/internal"
+)
+
+// aiProvider describes an LLM provider and the env vars that configure it.
+type aiProvider struct {
+	name    string
+	envVars []string          // all must be set for the provider to be "configured"
+	warns   []providerWarning // conditional warnings, checked when the provider is opted into
+	models  []string          // example model ids
+}
+
+type providerWarning struct {
+	condition func() bool
+	message   string
+	fix       string
+}
+
+// aiProviders is the data-driven registry doctor reports on. Adding a provider is a
+// data change, not new control flow.
+var aiProviders = []aiProvider{
+	{name: "OpenAI", envVars: []string{"OPENAI_API_KEY"}, models: []string{"openai/gpt-4o", "openai/gpt-4o-mini"}},
+	{name: "Anthropic", envVars: []string{"ANTHROPIC_API_KEY"}, models: []string{"anthropic/claude-sonnet-4-20250514", "anthropic/claude-3-5-sonnet-20241022"}},
+	{
+		name:    "Google Gemini",
+		envVars: []string{"GEMINI_API_KEY", "GOOGLE_CLOUD_PROJECT"},
+		warns: []providerWarning{{
+			condition: func() bool {
+				return os.Getenv("GEMINI_API_KEY") != "" && os.Getenv("GOOGLE_CLOUD_PROJECT") == ""
+			},
+			message: "GEMINI_API_KEY is set but GOOGLE_CLOUD_PROJECT is missing",
+			fix:     "export GOOGLE_CLOUD_PROJECT=your-gcp-project-id",
+		}},
+		models: []string{"google_gemini/gemini-2.0-flash", "google_gemini/gemini-1.5-pro"},
+	},
+	{
+		name:    "Azure OpenAI",
+		envVars: []string{"AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT"},
+		warns: []providerWarning{{
+			condition: func() bool {
+				return os.Getenv("AZURE_OPENAI_API_KEY") != "" && os.Getenv("AZURE_OPENAI_DEPLOYMENT") == ""
+			},
+			message: "AZURE_OPENAI_DEPLOYMENT is not set (required to route requests)",
+			fix:     "export AZURE_OPENAI_DEPLOYMENT=your-deployment-name",
+		}},
+		models: []string{"azure_openai/gpt-4o"},
+	},
+	{
+		name:    "AWS Bedrock",
+		envVars: []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"},
+		warns: []providerWarning{{
+			condition: func() bool {
+				return os.Getenv("AWS_ACCESS_KEY_ID") != "" && os.Getenv("AWS_DEFAULT_REGION") == "" && os.Getenv("AWS_REGION") == ""
+			},
+			message: "No AWS region set — defaults to us-east-1",
+			fix:     "export AWS_DEFAULT_REGION=us-east-1",
+		}},
+		models: []string{"aws_bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0"},
+	},
+	{name: "Mistral", envVars: []string{"MISTRAL_API_KEY"}, models: []string{"mistral/mistral-large-latest"}},
+	{name: "Cohere", envVars: []string{"COHERE_API_KEY"}, models: []string{"cohere/command-r-plus"}},
+	{name: "Grok", envVars: []string{"XAI_API_KEY"}, models: []string{"grok/grok-3"}},
+	{name: "Perplexity", envVars: []string{"PERPLEXITY_API_KEY"}, models: []string{"perplexity/sonar-pro"}},
+	{name: "Hugging Face", envVars: []string{"HUGGINGFACE_API_KEY"}, models: []string{"hugging_face/meta-llama/Llama-3-70b-chat-hf"}},
+	{name: "Stability AI", envVars: []string{"STABILITY_API_KEY"}, models: []string{"stabilityai/sd3.5-large"}},
+}
+
+var doctorCmd = &cobra.Command{
+	Use:          "doctor",
+	Short:        "Check the runtime and AI provider configuration",
+	GroupID:      "development",
+	SilenceUsage: true,
+	RunE:         runDoctor,
+}
+
+func runDoctor(cmd *cobra.Command, args []string) error {
+	issues := 0
+
+	fmt.Println("Runtime")
+	if ok, ver := commandVersion("java", "-version"); ok {
+		fmt.Printf("  ok  Java %s\n", ver)
+	} else {
+		fmt.Println("  --  Java not found (required by a local Conductor server; not needed for a remote server)")
+	}
+	if ok, ver := pythonVersion(); ok {
+		fmt.Printf("  ok  Python %s\n", ver)
+	} else {
+		fmt.Println("  --  Python not found (optional, needed for the Python SDK)")
+	}
+
+	fmt.Println("\nConductor server")
+	t := internal.Transport()
+	fmt.Printf("  ok  Server: %s\n", t.BaseURL)
+	if t.Tokens != nil {
+		fmt.Println("  ok  Authentication configured")
+	} else {
+		fmt.Println("  --  No authentication configured (anonymous; OSS only)")
+	}
+
+	fmt.Println("\nAI Providers")
+	configured := 0
+	for _, p := range aiProviders {
+		opted := providerOptedIn(p)
+		if isProviderConfigured(p) {
+			configured++
+			fmt.Printf("  ok  %s (%s)\n", p.name, strings.Join(p.envVars, ", "))
+			for _, m := range p.models {
+				fmt.Printf("        %s\n", m)
+			}
+		} else {
+			fmt.Printf("  --  %s (%s)\n", p.name, strings.Join(p.envVars, ", "))
+		}
+		if opted {
+			for _, w := range p.warns {
+				if w.condition() {
+					fmt.Printf("      !  %s\n", w.message)
+					fmt.Printf("         %s\n", w.fix)
+					issues++
+				}
+			}
+		}
+	}
+
+	fmt.Printf("\n%d AI provider(s) configured", configured)
+	if issues > 0 {
+		fmt.Printf(", %d warning(s)", issues)
+	}
+	fmt.Println(".")
+	return nil
+}
+
+// isProviderConfigured reports whether every required env var for a provider is set.
+func isProviderConfigured(p aiProvider) bool {
+	for _, env := range p.envVars {
+		if os.Getenv(env) == "" {
+			return false
+		}
+	}
+	return true
+}
+
+// providerOptedIn reports whether the user set at least one of a provider's env vars
+// (so its warnings are worth showing even if not fully configured).
+func providerOptedIn(p aiProvider) bool {
+	for _, env := range p.envVars {
+		if os.Getenv(env) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// commandVersion reports whether a command is on PATH and its first version line.
+func commandVersion(name string, args ...string) (bool, string) {
+	path, err := exec.LookPath(name)
+	if err != nil {
+		return false, ""
+	}
+	out, err := exec.Command(path, args...).CombinedOutput()
+	if err != nil {
+		return true, ""
+	}
+	return true, firstLine(string(out))
+}
+
+// pythonVersion probes python3 then python.
+func pythonVersion() (bool, string) {
+	for _, name := range []string{"python3", "python"} {
+		if ok, ver := commandVersion(name, "--version"); ok {
+			return true, ver
+		}
+	}
+	return false, ""
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return strings.TrimSpace(s)
+}
+
+func init() {
+	rootCmd.AddCommand(doctorCmd)
+}

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package cmd
+
+import "testing"
+
+func TestProviderConfiguredRequiresAllEnvVars(t *testing.T) {
+	p := aiProvider{name: "Test", envVars: []string{"DOC_TEST_KEY", "DOC_TEST_ENDPOINT"}}
+
+	if isProviderConfigured(p) {
+		t.Fatal("provider should not be configured with no env vars set")
+	}
+
+	t.Setenv("DOC_TEST_KEY", "x")
+	if isProviderConfigured(p) {
+		t.Error("provider should not be configured with only one of two env vars set")
+	}
+	if !providerOptedIn(p) {
+		t.Error("provider should be opted in once any env var is set")
+	}
+
+	t.Setenv("DOC_TEST_ENDPOINT", "y")
+	if !isProviderConfigured(p) {
+		t.Error("provider should be configured once all env vars are set")
+	}
+}
+
+func TestFirstLine(t *testing.T) {
+	if got := firstLine("openjdk version \"21\"\nmore\n"); got != `openjdk version "21"` {
+		t.Errorf("firstLine = %q", got)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,7 @@ import (
 	"github.com/conductor-sdk/conductor-go/sdk/settings"
 	cc "github.com/ivanpirog/coloredcobra"
 	"github.com/conductor-oss/conductor-cli/internal"
+	"github.com/conductor-oss/conductor-cli/internal/transport"
 	"github.com/conductor-oss/conductor-cli/internal/updater"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -134,7 +135,10 @@ var rootCmd = &cobra.Command{
 
 		log.Debug("Using Server ", url)
 
+		httpSettings := settings.NewHttpSettings(url)
+
 		var apiClient *client.APIClient
+		var agentTokens transport.TokenProvider
 
 		// Priority: auth-token > auth-key/secret
 		if token != "" {
@@ -147,10 +151,11 @@ var rootCmd = &cobra.Command{
 			}
 			apiClient = client.NewAPIClientWithTokenManager(
 				nil,
-				settings.NewHttpSettings(url),
+				httpSettings,
 				nil,
 				tokenManager,
 			)
+			agentTokens = newTokenProvider(tokenManager, httpSettings)
 		} else if key != "" && secret != "" {
 			cachedToken := viper.GetString("cached-token")
 			cachedExpiry := viper.GetInt64("cached-token-expiry")
@@ -176,24 +181,33 @@ var rootCmd = &cobra.Command{
 				cachedToken,
 				cachedExpiry,
 				configPath,
-				settings.NewHttpSettings(url),
+				httpSettings,
 			)
 
 			apiClient = client.NewAPIClientWithTokenManager(
 				nil,
-				settings.NewHttpSettings(url),
+				httpSettings,
 				nil,
 				tokenManager,
 			)
+			agentTokens = newTokenProvider(tokenManager, httpSettings)
 		} else {
 			// No authentication configured, create client without credentials
 			apiClient = client.NewAPIClient(
 				settings.NewAuthenticationSettings("", ""),
-				settings.NewHttpSettings(url),
+				httpSettings,
 			)
 		}
 
 		internal.SetAPIClient(apiClient)
+
+		// Share the same server URL and auth with the agent/skill transport, whose
+		// endpoints are not part of the conductor-go SDK. agentTokens is nil when no
+		// credentials are configured (anonymous access).
+		internal.SetTransport(transport.Config{
+			BaseURL: url,
+			Tokens:  agentTokens,
+		})
 
 		return nil
 	},

--- a/cmd/skill.go
+++ b/cmd/skill.go
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package cmd
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/conductor-oss/conductor-cli/internal"
+	"github.com/conductor-oss/conductor-cli/internal/skill"
+)
+
+const skillVersionDisplayLen = 12
+
+var skillCmd = &cobra.Command{
+	Use:     "skill",
+	Short:   "Manage skills",
+	GroupID: "conductor",
+}
+
+// ---- skill list ----
+
+var skillAllVersions bool
+
+var skillListCmd = &cobra.Command{
+	Use:          "list",
+	Short:        "List registered skills",
+	Args:         cobra.NoArgs,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		format, err := GetOutputFormat(cmd)
+		if err != nil {
+			return err
+		}
+		skills, err := internal.GetSkillService().List(cmd.Context(), skillAllVersions)
+		if err != nil {
+			return err
+		}
+		return renderSkillList(skills, format)
+	},
+}
+
+func renderSkillList(skills []skill.Summary, format OutputFormat) error {
+	switch format {
+	case OutputFormatJSON:
+		data, err := json.MarshalIndent(skills, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+	case OutputFormatCSV:
+		w := NewCSVWriter()
+		w.WriteHeader("NAME", "VERSION", "FILES", "AGENTS", "SCRIPTS", "RESOURCES", "DESCRIPTION")
+		for _, s := range skills {
+			w.WriteRow(s.Name, shortVersion(s.Version), strconv.Itoa(s.FileCount),
+				strconv.Itoa(s.SubAgentCount), strconv.Itoa(s.ScriptCount), strconv.Itoa(s.ResourceCount), s.Description)
+		}
+		w.Flush()
+	default:
+		if len(skills) == 0 {
+			fmt.Println("No skills registered.")
+			return nil
+		}
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		fmt.Fprintln(w, "NAME\tVERSION\tFILES\tAGENTS\tSCRIPTS\tRESOURCES\tDESCRIPTION")
+		for _, s := range skills {
+			fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%d\t%d\t%s\n",
+				s.Name, shortVersion(s.Version), s.FileCount, s.SubAgentCount, s.ScriptCount, s.ResourceCount, s.Description)
+		}
+		w.Flush()
+	}
+	return nil
+}
+
+// ---- skill get ----
+
+var skillGetVersion string
+
+var skillGetCmd = &cobra.Command{
+	Use:          "get <name> [version]",
+	Short:        "Get a registered skill",
+	Args:         cobra.RangeArgs(1, 2),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		detail, err := internal.GetSkillService().Get(cmd.Context(), args[0], versionArg(args, skillGetVersion))
+		if err != nil {
+			return err
+		}
+		data, err := json.MarshalIndent(detail, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+		return nil
+	},
+}
+
+// ---- skill pull ----
+
+var skillPullVersion string
+
+var skillPullCmd = &cobra.Command{
+	Use:          "pull <name> [destination]",
+	Short:        "Download and extract a skill package",
+	Args:         cobra.RangeArgs(1, 2),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := args[0]
+		dest := name
+		if len(args) > 1 {
+			dest = args[1]
+		}
+		svc := internal.GetSkillService()
+		detail, err := svc.Get(cmd.Context(), name, skillPullVersion)
+		if err != nil {
+			return err
+		}
+		data, err := svc.DownloadPackage(cmd.Context(), name, detail.Version)
+		if err != nil {
+			return err
+		}
+		if err := extractSkillPackage(data, dest); err != nil {
+			return err
+		}
+		fmt.Printf("Skill %s@%s pulled to %s.\n", detail.Name, detail.Version, dest)
+		return nil
+	},
+}
+
+// ---- skill delete ----
+
+var skillDeleteVersion string
+
+var skillDeleteCmd = &cobra.Command{
+	Use:          "delete <name> [version]",
+	Short:        "Delete a registered skill version",
+	Args:         cobra.RangeArgs(1, 2),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := args[0]
+		version := versionArg(args, skillDeleteVersion)
+		label := name
+		if version != "" {
+			label = name + "@" + version
+		}
+		if !confirmDeletion("skill", label) {
+			fmt.Println("Aborted.")
+			return nil
+		}
+		if err := internal.GetSkillService().Delete(cmd.Context(), name, version); err != nil {
+			return err
+		}
+		fmt.Printf("Deleted skill %s.\n", label)
+		return nil
+	},
+}
+
+// ---- helpers (file I/O lives in the cmd layer) ----
+
+// versionArg resolves the skill version from the optional positional arg or the
+// --version flag (positional wins, matching the AgentSpan CLI).
+func versionArg(args []string, flagVersion string) string {
+	if len(args) > 1 {
+		return args[1]
+	}
+	return flagVersion
+}
+
+func shortVersion(version string) string {
+	if len(version) > skillVersionDisplayLen {
+		return version[:skillVersionDisplayLen]
+	}
+	return version
+}
+
+// extractSkillPackage unzips a skill package into dest. Destination must be empty or
+// absent; entries are written through safePackagePath to prevent zip-slip.
+func extractSkillPackage(data []byte, dest string) error {
+	targetRoot, err := filepath.Abs(expandUserPath(dest))
+	if err != nil {
+		return fmt.Errorf("resolve destination: %w", err)
+	}
+	if entries, err := os.ReadDir(targetRoot); err == nil && len(entries) > 0 {
+		return fmt.Errorf("destination %q already exists and is not empty", targetRoot)
+	}
+	if err := os.MkdirAll(targetRoot, 0o755); err != nil {
+		return fmt.Errorf("create destination: %w", err)
+	}
+
+	reader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return fmt.Errorf("open skill package: %w", err)
+	}
+	for _, file := range reader.File {
+		if file.FileInfo().IsDir() {
+			continue
+		}
+		target, err := safePackagePath(targetRoot, file.Name)
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return fmt.Errorf("create directory for %s: %w", file.Name, err)
+		}
+		if err := writeZipEntry(file, target); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeZipEntry(file *zip.File, target string) error {
+	rc, err := file.Open()
+	if err != nil {
+		return fmt.Errorf("open package entry %s: %w", file.Name, err)
+	}
+	defer rc.Close()
+	out, err := os.OpenFile(target, os.O_CREATE|os.O_EXCL|os.O_WRONLY, file.Mode().Perm())
+	if err != nil {
+		return fmt.Errorf("create %s: %w", target, err)
+	}
+	if _, err := io.Copy(out, rc); err != nil {
+		out.Close()
+		return fmt.Errorf("extract %s: %w", file.Name, err)
+	}
+	return out.Close()
+}
+
+// safePackagePath joins relPath onto root, rejecting paths that escape root (zip-slip).
+func safePackagePath(root, relPath string) (string, error) {
+	cleanRel := filepath.Clean(filepath.FromSlash(relPath))
+	if filepath.IsAbs(cleanRel) || cleanRel == ".." || strings.HasPrefix(cleanRel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("package path %q is outside the skill directory", relPath)
+	}
+	target := filepath.Join(root, cleanRel)
+	if rel, err := filepath.Rel(root, target); err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("package path %q is outside the skill directory", relPath)
+	}
+	return target, nil
+}
+
+func expandUserPath(path string) string {
+	if path == "~" || strings.HasPrefix(path, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, strings.TrimPrefix(path, "~"))
+		}
+	}
+	return path
+}
+
+func init() {
+	skillListCmd.Flags().BoolVar(&skillAllVersions, "all-versions", false, "List all versions instead of only the latest")
+	AddOutputFlags(skillListCmd)
+
+	skillGetCmd.Flags().StringVar(&skillGetVersion, "version", "", "Skill version or checksum prefix")
+	skillPullCmd.Flags().StringVar(&skillPullVersion, "version", "", "Skill version or checksum prefix")
+	skillDeleteCmd.Flags().StringVar(&skillDeleteVersion, "version", "", "Skill version or checksum prefix")
+
+	skillCmd.AddCommand(
+		skillListCmd,
+		skillGetCmd,
+		skillPullCmd,
+		skillDeleteCmd,
+	)
+	rootCmd.AddCommand(skillCmd)
+}

--- a/cmd/skill_load.go
+++ b/cmd/skill_load.go
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/conductor-oss/conductor-cli/internal"
+	"github.com/conductor-oss/conductor-cli/internal/agent"
+)
+
+var (
+	skillLoadModel       string
+	skillLoadAgentModels []string
+	skillLoadSearchPaths []string
+)
+
+var skillLoadCmd = &cobra.Command{
+	Use:   "load <path>",
+	Short: "Package a local skill and deploy it as an agent",
+	Long: `Read a local skill directory, package its contents into a skill agent
+definition, and deploy it on the server for later execution via
+'conductor agent run --name <skill>'. Unlike 'skill run', load only publishes the
+agent; it does not start an execution.`,
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if skillLoadModel == "" {
+			return fmt.Errorf("--model is required for skill load")
+		}
+		agentModels, err := parseAgentModelFlags(skillLoadAgentModels)
+		if err != nil {
+			return err
+		}
+
+		cfg, local, err := BuildSkillPayload(args[0], PayloadOptions{
+			Model:       skillLoadModel,
+			AgentModels: agentModels,
+			SearchPaths: skillLoadSearchPaths,
+		})
+		if err != nil {
+			return err
+		}
+
+		raw, err := json.Marshal(cfg)
+		if err != nil {
+			return fmt.Errorf("encode skill config: %w", err)
+		}
+
+		result, err := internal.GetAgentService().Deploy(cmd.Context(), frameworkSkill, raw)
+		if err != nil {
+			return err
+		}
+		return renderDeployResult(local.SkillName, result)
+	},
+}
+
+// renderDeployResult prints a concise summary of a deployed skill agent, including
+// the tool task types the caller must serve (via 'skill run'/'skill serve') for the
+// agent to run end to end.
+func renderDeployResult(skillName string, result agent.DeployResult) error {
+	name := result.AgentName
+	if name == "" {
+		name = skillName
+	}
+	fmt.Printf("Skill %s deployed as agent %s.\n", skillName, name)
+	if len(result.RequiredWorkers) > 0 {
+		fmt.Println("Required workers:")
+		for _, w := range result.RequiredWorkers {
+			fmt.Printf("  - %s\n", w)
+		}
+	}
+	return nil
+}
+
+func init() {
+	skillLoadCmd.Flags().StringVar(&skillLoadModel, "model", "", "Orchestrator and default model (required)")
+	skillLoadCmd.Flags().StringArrayVar(&skillLoadAgentModels, "agent-model", nil, "Sub-agent model override (name=model, repeatable)")
+	skillLoadCmd.Flags().StringArrayVar(&skillLoadSearchPaths, "search-path", nil, "Cross-skill search directory (repeatable)")
+	skillCmd.AddCommand(skillLoadCmd)
+}

--- a/cmd/skill_materialize.go
+++ b/cmd/skill_materialize.go
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package cmd
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/conductor-oss/conductor-cli/internal/skill"
+	"github.com/conductor-oss/conductor-cli/internal/updater"
+)
+
+// skillCacheDirName is the sub-directory of the Conductor CLI config home under
+// which downloaded skill packages are cached (config-driven, never ~/.agentspan).
+const skillCacheDirName = "skills"
+
+var cacheSegmentUnsafe = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
+
+// materializeSkill resolves a skill argument to a local directory. A local skill
+// directory is used as-is; otherwise the argument is treated as a registered skill
+// name, downloaded (and cached), and its cache directory returned. detail is nil
+// for a local directory.
+func materializeSkill(ctx context.Context, svc skill.Service, skillArg, version string) (dir string, detail *skill.Detail, err error) {
+	if isSkillDirectory(skillArg) {
+		return skillArg, nil, nil
+	}
+	d, err := svc.Get(ctx, skillArg, version)
+	if err != nil {
+		return "", nil, fmt.Errorf("skill %q is not a local skill directory and was not found on the server: %w", skillArg, err)
+	}
+	dir, err = ensureCachedSkillPackage(ctx, svc, d)
+	if err != nil {
+		return "", nil, err
+	}
+	return dir, &d, nil
+}
+
+// ensureCachedSkillPackage returns the local files directory for a registered
+// skill, downloading and extracting the package when the cache is absent or stale.
+// The download is verified against the server checksum and installed atomically.
+func ensureCachedSkillPackage(ctx context.Context, svc skill.Service, detail skill.Detail) (string, error) {
+	cacheDir, filesDir, checksumPath, err := skillCachePaths(detail)
+	if err != nil {
+		return "", err
+	}
+	if isCachedSkillCurrent(filesDir, checksumPath, detail.Checksum) {
+		return filesDir, nil
+	}
+
+	data, err := svc.DownloadPackage(ctx, detail.Name, detail.Version)
+	if err != nil {
+		return "", err
+	}
+	if checksum := strings.TrimSpace(detail.Checksum); checksum != "" {
+		if actual := skillPackageChecksum(data); !strings.EqualFold(actual, checksum) {
+			return "", fmt.Errorf("downloaded skill package checksum mismatch for %s@%s: expected %s, got %s",
+				detail.Name, detail.Version, checksum, actual)
+		}
+	}
+
+	parentDir := filepath.Dir(cacheDir)
+	if err := os.MkdirAll(parentDir, 0o700); err != nil {
+		return "", fmt.Errorf("create skill cache parent: %w", err)
+	}
+	tmpDir, err := os.MkdirTemp(parentDir, "."+filepath.Base(cacheDir)+"-*")
+	if err != nil {
+		return "", fmt.Errorf("create temp skill cache: %w", err)
+	}
+	cleanupTmp := true
+	defer func() {
+		if cleanupTmp {
+			_ = os.RemoveAll(tmpDir)
+		}
+	}()
+
+	if err := extractSkillPackage(data, filepath.Join(tmpDir, "files")); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "checksum"), []byte(detail.Checksum), 0o600); err != nil {
+		return "", fmt.Errorf("write skill cache checksum: %w", err)
+	}
+	if err := os.RemoveAll(cacheDir); err != nil {
+		return "", fmt.Errorf("clear stale skill cache: %w", err)
+	}
+	if err := os.Rename(tmpDir, cacheDir); err != nil {
+		return "", fmt.Errorf("install skill cache: %w", err)
+	}
+	cleanupTmp = false
+	return filesDir, nil
+}
+
+// skillCachePaths derives the cache directory for a skill under the Conductor CLI
+// config home (config-driven, not ~/.agentspan).
+func skillCachePaths(detail skill.Detail) (cacheDir, filesDir, checksumPath string, err error) {
+	configDir, err := updater.GetConfigDir()
+	if err != nil {
+		return "", "", "", fmt.Errorf("resolve config directory: %w", err)
+	}
+	cacheDir = filepath.Join(configDir, skillCacheDirName, safeCacheSegment(detail.Name), safeCacheSegment(detail.Version))
+	return cacheDir, filepath.Join(cacheDir, "files"), filepath.Join(cacheDir, "checksum"), nil
+}
+
+// safeCacheSegment makes a name/version safe as a single path segment, disambiguating
+// with a content hash suffix when characters had to be replaced.
+func safeCacheSegment(value string) string {
+	cleaned := strings.Trim(cacheSegmentUnsafe.ReplaceAllString(value, "_"), "._-")
+	if cleaned == "" {
+		cleaned = "unnamed"
+	}
+	if cleaned != value {
+		sum := sha256.Sum256([]byte(value))
+		cleaned = cleaned + "-" + hex.EncodeToString(sum[:])[:8]
+	}
+	return cleaned
+}
+
+func skillPackageChecksum(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// isCachedSkillCurrent reports whether a cached skill's files exist and match the
+// expected checksum.
+func isCachedSkillCurrent(filesDir, checksumPath, checksum string) bool {
+	if !isSkillDirectory(filesDir) {
+		return false
+	}
+	if checksum == "" {
+		return true
+	}
+	data, err := os.ReadFile(checksumPath)
+	return err == nil && strings.TrimSpace(string(data)) == checksum
+}

--- a/cmd/skill_payload.go
+++ b/cmd/skill_payload.go
@@ -1,0 +1,546 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/conductor-oss/conductor-cli/internal/skillworker"
+)
+
+// frameworkSkill is the framework marker for skill-backed agent definitions; it is
+// the envelope selector sent to /api/agent/deploy and /api/agent/start.
+const frameworkSkill = "skill"
+
+// skillSectionSplitBytes is the SKILL.md body size (~50 KB) above which the builder
+// pre-splits the instructions into per-heading sections that the read_skill_file
+// worker can serve on demand instead of shipping the whole body inline.
+const skillSectionSplitBytes = 50 << 10
+
+const (
+	scriptsDirName        = "scripts"            // optional executables directory inside a skill
+	agentFileSuffix       = "-agent.md"          // sub-agent instruction files: "{name}-agent.md"
+	defaultScriptLanguage = skillworker.LangBash // language for scripts with an unknown extension
+)
+
+// scriptLanguageByExt maps a script file extension to its execution language. The
+// language vocabulary is owned by skillworker (which executes scripts), so the two
+// sides cannot drift. Extensions absent here fall back to defaultScriptLanguage.
+var scriptLanguageByExt = map[string]string{
+	".py":  skillworker.LangPython,
+	".sh":  skillworker.LangBash,
+	".bat": skillworker.LangBatch,
+	".cmd": skillworker.LangBatch,
+	".js":  skillworker.LangNode,
+	".mjs": skillworker.LangNode,
+	".ts":  skillworker.LangNode,
+	".rb":  skillworker.LangRuby,
+	".go":  skillworker.LangGo,
+}
+
+// skillResourceDirs are the sub-directories whose files are exposed as skill
+// resources (in addition to eligible root-level files).
+var skillResourceDirs = []string{"references", "examples", "assets"}
+
+// agentsSkillsSubpath is the conventional per-project / per-user skill library
+// location (".agents/skills") searched when resolving cross-skill references.
+var agentsSkillsSubpath = filepath.Join(".agents", "skills")
+
+// crossSkillRefPattern matches prose like "invoke the foo skill" / "use bar skill"
+// in a SKILL.md body, capturing the referenced skill name.
+var crossSkillRefPattern = regexp.MustCompile(`(?i)(?:invoke|use|call)\s+(?:the\s+)?([a-z][a-z0-9-]*)\s+skill`)
+
+// sectionHeadingPrefix marks a level-2 markdown heading; the body is split into
+// sections at each line that begins with it.
+const sectionHeadingPrefix = "## "
+
+// SkillConfig is the server-bound skill definition. Every field is serialized to
+// the deploy/start rawConfig; there are no local-only fields (paths and pre-split
+// sections live in LocalContext instead), so no strip step is needed before the
+// wire — the type is the contract.
+type SkillConfig struct {
+	Model          string                 `json:"model,omitempty"`
+	AgentModels    map[string]string      `json:"agentModels,omitempty"`
+	SkillMd        string                 `json:"skillMd"`
+	AgentFiles     map[string]string      `json:"agentFiles,omitempty"`     // agentName → body
+	Scripts        map[string]ScriptInfo  `json:"scripts,omitempty"`        // toolName → {filename,language}
+	ResourceFiles  []string               `json:"resourceFiles,omitempty"`  // skill-relative paths
+	CrossSkillRefs map[string]SkillConfig `json:"crossSkillRefs,omitempty"` // refName → nested config
+	DefaultParams  map[string]ParamValue  `json:"defaultParams,omitempty"`
+	Params         map[string]ParamValue  `json:"params,omitempty"`
+	// Workspace is set only by the run/serve worker runtime; load never populates it.
+	// The wire type is owned by skillworker (which serves the workspace tools).
+	Workspace *skillworker.WorkspaceWire `json:"workspace,omitempty"`
+}
+
+// ScriptInfo describes one discovered script tool.
+type ScriptInfo struct {
+	Filename string `json:"filename"`
+	Language string `json:"language"`
+}
+
+// ParamValue is one skill-parameter value. Skill params are scalars: a --param
+// override parses to a bool ("true"/"false") or a string, and a SKILL.md
+// frontmatter default carries through its parsed YAML scalar. ParamValue keeps the
+// value typed at the wire boundary (SkillConfig holds no bare interface{} map) and
+// both marshals to, and stringifies as, its underlying scalar.
+type ParamValue struct {
+	v any
+}
+
+func rawParamValue(v any) ParamValue { return ParamValue{v: v} }
+
+// MarshalJSON emits the underlying scalar.
+func (p ParamValue) MarshalJSON() ([]byte, error) { return json.Marshal(p.v) }
+
+// format renders the value for the [Skill Parameters] block injected into SKILL.md.
+func (p ParamValue) format() string { return fmt.Sprint(p.v) }
+
+// LocalContext is the never-serialized side of a built skill. It stays on the CLI
+// side and feeds the run/serve workers: the skill name is the worker task-type
+// prefix, SkillDir roots local file/script tools, Sections lets the read_skill_file
+// worker serve "skill_section:{slug}" requests for large bodies, and CrossSkills
+// carries the same context for each resolved cross-skill so their script/file
+// workers can be started too.
+type LocalContext struct {
+	SkillName   string
+	SkillDir    string
+	Sections    map[string]string       // slug → SKILL.md section body
+	CrossSkills map[string]LocalContext // refName → nested local context
+}
+
+// PayloadOptions carries the caller-resolved (in cmd) inputs the builder needs.
+type PayloadOptions struct {
+	Model          string
+	AgentModels    map[string]string
+	SearchPaths    []string
+	ParamOverrides map[string]ParamValue
+}
+
+// BuildSkillPayload reads a local skill directory and produces its typed wire
+// config plus the local-only context. All filesystem access stays here in the cmd
+// layer; the returned SkillConfig is pure data ready to marshal for deploy/start.
+func BuildSkillPayload(dir string, opts PayloadOptions) (SkillConfig, LocalContext, error) {
+	return buildSkillPayloadInternal(dir, opts, map[string]bool{})
+}
+
+func buildSkillPayloadInternal(dir string, opts PayloadOptions, seen map[string]bool) (SkillConfig, LocalContext, error) {
+	absPath, err := filepath.Abs(expandUserPath(dir))
+	if err != nil {
+		return SkillConfig{}, LocalContext{}, fmt.Errorf("resolve path: %w", err)
+	}
+	absPath, err = filepath.EvalSymlinks(absPath)
+	if err != nil {
+		return SkillConfig{}, LocalContext{}, fmt.Errorf("resolve path: %w", err)
+	}
+
+	skillMdContent, err := os.ReadFile(filepath.Join(absPath, skillMarkdownFile))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return SkillConfig{}, LocalContext{}, fmt.Errorf("directory %q is not a valid skill: %s not found", absPath, skillMarkdownFile)
+		}
+		return SkillConfig{}, LocalContext{}, fmt.Errorf("read %s: %w", skillMarkdownFile, err)
+	}
+
+	frontmatter, err := parseFrontmatter(string(skillMdContent))
+	if err != nil {
+		return SkillConfig{}, LocalContext{}, fmt.Errorf("parse %s frontmatter: %w", skillMarkdownFile, err)
+	}
+	skillName, _ := frontmatter["name"].(string)
+	if skillName == "" {
+		return SkillConfig{}, LocalContext{}, fmt.Errorf("%s missing required 'name' field in frontmatter", skillMarkdownFile)
+	}
+
+	agentFiles, err := discoverAgentFiles(absPath)
+	if err != nil {
+		return SkillConfig{}, LocalContext{}, fmt.Errorf("discover agent files: %w", err)
+	}
+	scripts, err := discoverScripts(absPath)
+	if err != nil {
+		return SkillConfig{}, LocalContext{}, fmt.Errorf("discover scripts: %w", err)
+	}
+	resourceFiles, err := collectResourceFiles(absPath)
+	if err != nil {
+		return SkillConfig{}, LocalContext{}, fmt.Errorf("collect resource files: %w", err)
+	}
+	crossRefs, crossLocals, err := resolveCrossSkills(string(skillMdContent), absPath, opts, seen)
+	if err != nil {
+		return SkillConfig{}, LocalContext{}, err
+	}
+
+	// Params: frontmatter defaults overlaid with caller overrides, then rendered
+	// into SKILL.md so the server-side orchestrator sees them.
+	defaultParams := extractDefaultParams(frontmatter)
+	mergedParams := mergeParams(defaultParams, opts.ParamOverrides)
+	skillMd := string(skillMdContent)
+	if len(mergedParams) > 0 {
+		skillMd = skillMd + "\n\n" + formatParamMap(mergedParams) + "\n"
+	}
+
+	sections := splitSkillSections(extractBody(skillMd))
+
+	cfg := SkillConfig{
+		Model:          opts.Model,
+		AgentModels:    opts.AgentModels,
+		SkillMd:        skillMd,
+		AgentFiles:     agentFiles,
+		Scripts:        scripts,
+		ResourceFiles:  resourceFiles,
+		CrossSkillRefs: crossRefs,
+		DefaultParams:  defaultParams,
+		Params:         mergedParams,
+	}
+	local := LocalContext{SkillName: skillName, SkillDir: absPath, Sections: sections, CrossSkills: crossLocals}
+	return cfg, local, nil
+}
+
+// discoverAgentFiles globs "*-agent.md" and maps agent name → file body.
+func discoverAgentFiles(skillDir string) (map[string]string, error) {
+	matches, err := filepath.Glob(filepath.Join(skillDir, "*"+agentFileSuffix))
+	if err != nil {
+		return nil, fmt.Errorf("glob agent files: %w", err)
+	}
+	if len(matches) == 0 {
+		return nil, nil
+	}
+	result := make(map[string]string, len(matches))
+	for _, match := range matches {
+		base := filepath.Base(match)
+		content, err := os.ReadFile(match)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", base, err)
+		}
+		result[strings.TrimSuffix(base, agentFileSuffix)] = string(content)
+	}
+	return result, nil
+}
+
+// discoverScripts lists files in scripts/ and maps tool name → script info. The
+// directory is optional.
+func discoverScripts(skillDir string) (map[string]ScriptInfo, error) {
+	entries, err := os.ReadDir(filepath.Join(skillDir, scriptsDirName))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read scripts directory: %w", err)
+	}
+	result := make(map[string]ScriptInfo)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		filename := entry.Name()
+		toolName := strings.TrimSuffix(filename, filepath.Ext(filename))
+		if toolName == "" {
+			toolName = filename
+		}
+		result[toolName] = ScriptInfo{Filename: filename, Language: detectScriptLanguage(filename)}
+	}
+	if len(result) == 0 {
+		return nil, nil
+	}
+	return result, nil
+}
+
+// detectScriptLanguage maps a filename to its language via scriptLanguageByExt,
+// defaulting to defaultScriptLanguage.
+func detectScriptLanguage(filename string) string {
+	if lang, ok := scriptLanguageByExt[strings.ToLower(filepath.Ext(filename))]; ok {
+		return lang
+	}
+	return defaultScriptLanguage
+}
+
+// collectResourceFiles lists resource-dir files plus eligible root files (excluding
+// SKILL.md and *-agent.md) as skill-relative slash paths, honoring the ignore file.
+func collectResourceFiles(skillDir string) ([]string, error) {
+	ignore, err := loadSkillPackageIgnore(skillDir)
+	if err != nil {
+		return nil, err
+	}
+	var result []string
+	for _, subdir := range skillResourceDirs {
+		dir := filepath.Join(skillDir, subdir)
+		if _, statErr := os.Stat(dir); os.IsNotExist(statErr) {
+			continue
+		}
+		walkErr := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				return nil
+			}
+			rel, relErr := filepath.Rel(skillDir, path)
+			if relErr != nil {
+				return relErr
+			}
+			rel = filepath.ToSlash(rel)
+			if shouldExcludeSkillPackagePath(rel, false, ignore) {
+				return nil
+			}
+			result = append(result, rel)
+			return nil
+		})
+		if walkErr != nil {
+			return nil, fmt.Errorf("walk %s: %w", subdir, walkErr)
+		}
+	}
+
+	entries, err := os.ReadDir(skillDir)
+	if err != nil {
+		return nil, fmt.Errorf("read skill directory: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if shouldExcludeSkillPackagePath(name, false, ignore) || name == skillMarkdownFile || strings.HasSuffix(name, agentFileSuffix) {
+			continue
+		}
+		result = append(result, name)
+	}
+	return result, nil
+}
+
+// resolveCrossSkills packages referenced sibling/project/user skills recursively,
+// guarding against cycles. It returns the typed wire configs (no local fields leak
+// into them — what removes the original's strip step) paired with their local
+// contexts (so run/serve can start each cross-skill's workers).
+func resolveCrossSkills(skillMd, skillDir string, opts PayloadOptions, seen map[string]bool) (map[string]SkillConfig, map[string]LocalContext, error) {
+	refNames := referencedSkillNames(skillMd)
+	if len(refNames) == 0 {
+		return nil, nil, nil
+	}
+
+	searchDirs := []string{filepath.Dir(skillDir), filepath.Join(".", agentsSkillsSubpath)}
+	if home, err := os.UserHomeDir(); err == nil {
+		searchDirs = append(searchDirs, filepath.Join(home, agentsSkillsSubpath))
+	}
+	searchDirs = append(searchDirs, opts.SearchPaths...)
+
+	refs := make(map[string]SkillConfig)
+	locals := make(map[string]LocalContext)
+	for _, refName := range refNames {
+		refDir, ok := findSkillDir(refName, searchDirs)
+		if !ok {
+			continue
+		}
+		refAbs, err := filepath.Abs(refDir)
+		if err != nil {
+			return nil, nil, err
+		}
+		refAbs, err = filepath.EvalSymlinks(refAbs)
+		if err != nil {
+			return nil, nil, err
+		}
+		if refAbs == skillDir {
+			continue
+		}
+		if seen[refAbs] {
+			return nil, nil, fmt.Errorf("circular skill reference detected: %s", refName)
+		}
+		nextSeen := make(map[string]bool, len(seen)+1)
+		for k, v := range seen {
+			nextSeen[k] = v
+		}
+		nextSeen[skillDir] = true
+
+		refCfg, refLocal, err := buildSkillPayloadInternal(refAbs, opts, nextSeen)
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolve cross-skill %q: %w", refName, err)
+		}
+		refs[refName] = refCfg
+		locals[refName] = refLocal
+	}
+	if len(refs) == 0 {
+		return nil, nil, nil
+	}
+	return refs, locals, nil
+}
+
+// referencedSkillNames returns the de-duplicated, sorted skill names referenced in
+// the SKILL.md body prose.
+func referencedSkillNames(skillMd string) []string {
+	matches := crossSkillRefPattern.FindAllStringSubmatch(extractBody(skillMd), -1)
+	seen := make(map[string]bool)
+	var names []string
+	for _, m := range matches {
+		name := strings.ToLower(m[1])
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// findSkillDir returns the first search dir that contains "{name}/SKILL.md".
+func findSkillDir(name string, dirs []string) (string, bool) {
+	for _, dir := range dirs {
+		if dir == "" {
+			continue
+		}
+		candidate := filepath.Join(expandUserPath(dir), name)
+		if _, err := os.Stat(filepath.Join(candidate, skillMarkdownFile)); err == nil {
+			return candidate, true
+		}
+	}
+	return "", false
+}
+
+// extractBody returns the markdown body after the YAML frontmatter (mirrors the
+// register command's parseFrontmatter, which returns the parsed head).
+func extractBody(content string) string {
+	content = strings.TrimSpace(content)
+	if !strings.HasPrefix(content, "---") {
+		return content
+	}
+	rest := strings.TrimPrefix(content[3:], "\n")
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return content
+	}
+	return strings.TrimPrefix(rest[end+4:], "\n")
+}
+
+// extractDefaultParams reads frontmatter "params" defaults. A param may be given as
+// a scalar or as a "{default: ...}" object; both collapse to a ParamValue.
+func extractDefaultParams(frontmatter map[string]any) map[string]ParamValue {
+	params, ok := frontmatter["params"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	defaults := make(map[string]ParamValue, len(params))
+	for name, raw := range params {
+		if def, ok := raw.(map[string]any); ok {
+			if value, exists := def["default"]; exists {
+				defaults[name] = rawParamValue(value)
+				continue
+			}
+		}
+		defaults[name] = rawParamValue(raw)
+	}
+	if len(defaults) == 0 {
+		return nil
+	}
+	return defaults
+}
+
+// mergeParams overlays overrides onto defaults (overrides win).
+func mergeParams(defaults, overrides map[string]ParamValue) map[string]ParamValue {
+	if len(defaults) == 0 && len(overrides) == 0 {
+		return nil
+	}
+	merged := make(map[string]ParamValue, len(defaults)+len(overrides))
+	for k, v := range defaults {
+		merged[k] = v
+	}
+	for k, v := range overrides {
+		merged[k] = v
+	}
+	return merged
+}
+
+// formatParamMap renders a deterministic "[Skill Parameters]" block.
+func formatParamMap(params map[string]ParamValue) string {
+	if len(params) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(params))
+	for k := range params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var sb strings.Builder
+	sb.WriteString("[Skill Parameters]\n")
+	for i, k := range keys {
+		if i > 0 {
+			sb.WriteString("\n")
+		}
+		sb.WriteString(k)
+		sb.WriteString(": ")
+		sb.WriteString(params[k].format())
+	}
+	return sb.String()
+}
+
+// splitSkillSections breaks a large body into slug → "## section" bodies so the
+// read_skill_file worker can serve them on demand. It scans line by line, starting
+// a new section at each heading line (Go's RE2 has no look-ahead, so a split regex
+// is not an option). Small bodies, and bodies with no headings, return nil.
+func splitSkillSections(body string) map[string]string {
+	if len(body) <= skillSectionSplitBytes {
+		return nil
+	}
+	sections := make(map[string]string)
+	var block []string
+	flush := func() {
+		if len(block) == 0 {
+			return
+		}
+		section := strings.TrimSpace(strings.Join(block, "\n"))
+		block = block[:0]
+		if !strings.HasPrefix(section, sectionHeadingPrefix) {
+			return // discard the pre-heading preamble
+		}
+		firstLine := strings.SplitN(section, "\n", 2)[0]
+		slug := slugifyHeading(strings.TrimSpace(strings.TrimPrefix(firstLine, sectionHeadingPrefix)))
+		if slug != "" {
+			sections[slug] = section
+		}
+	}
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(line, sectionHeadingPrefix) {
+			flush()
+		}
+		block = append(block, line)
+	}
+	flush()
+	if len(sections) == 0 {
+		return nil
+	}
+	return sections
+}
+
+// slugifyHeading lowercases text and collapses runs of spaces/dashes into single
+// dashes, keeping only [a-z0-9-].
+func slugifyHeading(text string) string {
+	text = strings.ToLower(text)
+	var sb strings.Builder
+	lastDash := false
+	for _, r := range text {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			sb.WriteRune(r)
+			lastDash = false
+		case r == ' ' || r == '\t' || r == '-':
+			if !lastDash && sb.Len() > 0 {
+				sb.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+	return strings.Trim(sb.String(), "-")
+}

--- a/cmd/skill_payload_test.go
+++ b/cmd/skill_payload_test.go
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeSkillFile writes content to dir/rel, creating parent directories.
+func writeSkillFile(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	full := filepath.Join(dir, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("mkdir for %s: %v", rel, err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}
+
+func TestBuildSkillPayloadTypedFields(t *testing.T) {
+	dir := t.TempDir()
+	writeSkillFile(t, dir, "SKILL.md", "---\nname: demo\nparams:\n  tone:\n    default: friendly\n  verbose: false\n---\nBody text.\n")
+	writeSkillFile(t, dir, "planner-agent.md", "You plan.")
+	writeSkillFile(t, dir, "scripts/greet.py", "print('hi')")
+	writeSkillFile(t, dir, "scripts/build.sh", "echo build")
+	writeSkillFile(t, dir, "references/guide.md", "guide")
+	writeSkillFile(t, dir, "notes.txt", "root resource")
+
+	cfg, local, err := BuildSkillPayload(dir, PayloadOptions{
+		Model:       "gpt-x",
+		AgentModels: map[string]string{"planner": "gpt-mini"},
+	})
+	if err != nil {
+		t.Fatalf("BuildSkillPayload: %v", err)
+	}
+
+	if cfg.Model != "gpt-x" {
+		t.Errorf("Model = %q, want gpt-x", cfg.Model)
+	}
+	if cfg.AgentModels["planner"] != "gpt-mini" {
+		t.Errorf("AgentModels = %v", cfg.AgentModels)
+	}
+	if body := cfg.AgentFiles["planner"]; body != "You plan." {
+		t.Errorf("AgentFiles[planner] = %q", body)
+	}
+	if got := cfg.Scripts["greet"]; got.Filename != "greet.py" || got.Language != "python" {
+		t.Errorf("Scripts[greet] = %+v", got)
+	}
+	if got := cfg.Scripts["build"]; got.Filename != "build.sh" || got.Language != "bash" {
+		t.Errorf("Scripts[build] = %+v", got)
+	}
+	if !containsString(cfg.ResourceFiles, "references/guide.md") || !containsString(cfg.ResourceFiles, "notes.txt") {
+		t.Errorf("ResourceFiles = %v", cfg.ResourceFiles)
+	}
+	// SKILL.md and *-agent.md must never be listed as resources.
+	if containsString(cfg.ResourceFiles, "SKILL.md") || containsString(cfg.ResourceFiles, "planner-agent.md") {
+		t.Errorf("ResourceFiles leaked non-resource files: %v", cfg.ResourceFiles)
+	}
+	// Frontmatter defaults: {default: friendly} collapses to the value; scalar carries through.
+	if cfg.DefaultParams["tone"].format() != "friendly" || cfg.DefaultParams["verbose"].format() != "false" {
+		t.Errorf("DefaultParams = tone=%q verbose=%q", cfg.DefaultParams["tone"].format(), cfg.DefaultParams["verbose"].format())
+	}
+	// Params get injected into skillMd for server visibility.
+	if !strings.Contains(cfg.SkillMd, "[Skill Parameters]") || !strings.Contains(cfg.SkillMd, "tone: friendly") {
+		t.Errorf("skillMd missing injected params:\n%s", cfg.SkillMd)
+	}
+	if local.SkillName != "demo" {
+		t.Errorf("LocalContext.SkillName = %q, want demo", local.SkillName)
+	}
+	if !filepath.IsAbs(local.SkillDir) {
+		t.Errorf("LocalContext.SkillDir not absolute: %q", local.SkillDir)
+	}
+}
+
+// TestBuildSkillPayloadParamOverride verifies overrides win over frontmatter defaults.
+func TestBuildSkillPayloadParamOverride(t *testing.T) {
+	dir := t.TempDir()
+	writeSkillFile(t, dir, "SKILL.md", "---\nname: demo\nparams:\n  tone:\n    default: friendly\n---\nBody.\n")
+
+	cfg, _, err := BuildSkillPayload(dir, PayloadOptions{
+		Model:          "m",
+		ParamOverrides: map[string]ParamValue{"tone": rawParamValue("terse")},
+	})
+	if err != nil {
+		t.Fatalf("BuildSkillPayload: %v", err)
+	}
+	if cfg.Params["tone"].format() != "terse" {
+		t.Errorf("merged param tone = %q, want terse", cfg.Params["tone"].format())
+	}
+	if !strings.Contains(cfg.SkillMd, "tone: terse") {
+		t.Errorf("skillMd should carry the overridden param:\n%s", cfg.SkillMd)
+	}
+}
+
+// TestBuildSkillPayloadWireLocalSplit asserts the wire type carries no local paths
+// and the local context carries no server fields — the invariant that replaces the
+// original's _skill-prefixed keys and stripLocalSkillFields step.
+func TestBuildSkillPayloadWireLocalSplit(t *testing.T) {
+	dir := t.TempDir()
+	writeSkillFile(t, dir, "SKILL.md", "---\nname: demo\n---\nBody.\n")
+
+	cfg, local, err := BuildSkillPayload(dir, PayloadOptions{Model: "m"})
+	if err != nil {
+		t.Fatalf("BuildSkillPayload: %v", err)
+	}
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	wire := string(raw)
+	for _, banned := range []string{"_skill", "skillPath", "skillDir", local.SkillDir} {
+		if strings.Contains(wire, banned) {
+			t.Errorf("wire config leaked %q: %s", banned, wire)
+		}
+	}
+	// No local-context field name should appear as a JSON key either.
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, k := range []string{"sections", "skillDir", "skillName"} {
+		if _, ok := probe[k]; ok {
+			t.Errorf("wire config unexpectedly has key %q", k)
+		}
+	}
+}
+
+// TestBuildSkillPayloadCrossSkillRecursion checks a referenced sibling skill is
+// packaged recursively as a nested typed config.
+func TestBuildSkillPayloadCrossSkillRecursion(t *testing.T) {
+	root := t.TempDir()
+	main := filepath.Join(root, "main")
+	writeSkillFile(t, main, "SKILL.md", "---\nname: main\n---\nPlease invoke the helper skill to assist.\n")
+	helper := filepath.Join(root, "helper")
+	writeSkillFile(t, helper, "SKILL.md", "---\nname: helper\n---\nHelper body.\n")
+	writeSkillFile(t, helper, "scripts/aid.sh", "echo aid")
+
+	cfg, _, err := BuildSkillPayload(main, PayloadOptions{Model: "m"})
+	if err != nil {
+		t.Fatalf("BuildSkillPayload: %v", err)
+	}
+	ref, ok := cfg.CrossSkillRefs["helper"]
+	if !ok {
+		t.Fatalf("expected cross-skill ref 'helper', got %v", keysOfStringMap(cfg.CrossSkillRefs))
+	}
+	if _, ok := ref.Scripts["aid"]; !ok {
+		t.Errorf("nested helper config missing its script: %+v", ref.Scripts)
+	}
+}
+
+// TestBuildSkillPayloadCycleGuard ensures a circular reference is rejected, not
+// recursed forever.
+func TestBuildSkillPayloadCycleGuard(t *testing.T) {
+	root := t.TempDir()
+	a := filepath.Join(root, "alpha")
+	writeSkillFile(t, a, "SKILL.md", "---\nname: alpha\n---\nUse the beta skill.\n")
+	b := filepath.Join(root, "beta")
+	writeSkillFile(t, b, "SKILL.md", "---\nname: beta\n---\nUse the alpha skill.\n")
+
+	_, _, err := BuildSkillPayload(a, PayloadOptions{Model: "m"})
+	if err == nil {
+		t.Fatal("expected a circular skill reference error")
+	}
+	if !strings.Contains(err.Error(), "circular") {
+		t.Errorf("error = %v, want a circular-reference error", err)
+	}
+}
+
+// TestBuildSkillPayloadRequiresName rejects a SKILL.md without a name.
+func TestBuildSkillPayloadRequiresName(t *testing.T) {
+	dir := t.TempDir()
+	writeSkillFile(t, dir, "SKILL.md", "---\ndescription: no name here\n---\nBody.\n")
+	if _, _, err := BuildSkillPayload(dir, PayloadOptions{Model: "m"}); err == nil {
+		t.Fatal("expected an error for a SKILL.md missing 'name'")
+	}
+}
+
+// TestSplitSkillSectionsLargeBody exercises the section split above the threshold.
+func TestSplitSkillSectionsLargeBody(t *testing.T) {
+	filler := strings.Repeat("x", skillSectionSplitBytes)
+	body := "## First Heading\n" + filler + "\n## Second Heading\nmore\n"
+	sections := splitSkillSections(body)
+	if _, ok := sections["first-heading"]; !ok {
+		t.Errorf("missing first-heading section: %v", keysOfStringMap2(sections))
+	}
+	if _, ok := sections["second-heading"]; !ok {
+		t.Errorf("missing second-heading section: %v", keysOfStringMap2(sections))
+	}
+	// Small bodies do not split.
+	if splitSkillSections("## Tiny\nshort") != nil {
+		t.Error("small body should not be split")
+	}
+}
+
+func containsString(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}
+
+func keysOfStringMap(m map[string]SkillConfig) []string {
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	return ks
+}
+
+func keysOfStringMap2(m map[string]string) []string {
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	return ks
+}

--- a/cmd/skill_register.go
+++ b/cmd/skill_register.go
@@ -1,0 +1,391 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package cmd
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	pathpkg "path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/conductor-oss/conductor-cli/internal"
+)
+
+// skillPackageFile is the per-file manifest entry sent to the server.
+type skillPackageFile struct {
+	Path        string `json:"path"`
+	Size        int64  `json:"size"`
+	SHA256      string `json:"sha256"`
+	ContentType string `json:"contentType"`
+}
+
+type skillPackageSource struct {
+	FullPath string
+	RelPath  string
+	Mode     os.FileMode
+}
+
+// skillManifest is the JSON manifest uploaded alongside the package zip. It is a
+// typed struct so the wire shape is explicit and no map crosses a layer boundary.
+type skillManifest struct {
+	Name        string             `json:"name"`
+	Version     string             `json:"version,omitempty"`
+	Description string             `json:"description,omitempty"`
+	Metadata    any                `json:"metadata,omitempty"`
+	Model       string             `json:"model,omitempty"`
+	AgentModels map[string]string  `json:"agentModels,omitempty"`
+	Files       []skillPackageFile `json:"files"`
+}
+
+var (
+	skillRegisterVersion     string
+	skillRegisterModel       string
+	skillRegisterAgentModels []string
+)
+
+var skillRegisterCmd = &cobra.Command{
+	Use:          "register <path>",
+	Short:        "Package and register a local skill with the server",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		path := args[0]
+		if !isSkillDirectory(path) {
+			return fmt.Errorf("%q is not a skill directory (SKILL.md not found)", path)
+		}
+		pkg, files, err := buildSkillPackage(path)
+		if err != nil {
+			return err
+		}
+		manifest, err := buildSkillManifest(path, skillRegisterVersion, skillRegisterModel, skillRegisterAgentModels, files)
+		if err != nil {
+			return err
+		}
+		detail, err := internal.GetSkillService().Register(cmd.Context(), manifest, pkg)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Skill %s registered as version %s.\n", detail.Name, detail.Version)
+		return nil
+	},
+}
+
+// buildSkillManifest reads SKILL.md frontmatter and assembles the upload manifest.
+func buildSkillManifest(skillDir, version, model string, agentModelFlags []string, files []skillPackageFile) (json.RawMessage, error) {
+	data, err := os.ReadFile(filepath.Join(expandUserPath(skillDir), skillMarkdownFile))
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", skillMarkdownFile, err)
+	}
+	frontmatter, err := parseFrontmatter(string(data))
+	if err != nil {
+		return nil, err
+	}
+	name, _ := frontmatter["name"].(string)
+	if name == "" {
+		return nil, fmt.Errorf("%s is missing the required 'name' field in its frontmatter", skillMarkdownFile)
+	}
+	description, _ := frontmatter["description"].(string)
+	agentModels, err := parseAgentModelFlags(agentModelFlags)
+	if err != nil {
+		return nil, err
+	}
+	manifest := skillManifest{
+		Name:        name,
+		Version:     version,
+		Description: description,
+		Metadata:    frontmatter["metadata"],
+		Model:       model,
+		AgentModels: agentModels,
+		Files:       files,
+	}
+	return json.Marshal(manifest)
+}
+
+const skillMarkdownFile = "SKILL.md"
+
+// isSkillDirectory reports whether path is a directory containing a SKILL.md.
+func isSkillDirectory(path string) bool {
+	expanded := expandUserPath(path)
+	info, err := os.Stat(expanded)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	_, err = os.Stat(filepath.Join(expanded, skillMarkdownFile))
+	return err == nil
+}
+
+// buildSkillPackage zips a skill directory deterministically and returns the bytes
+// plus the per-file manifest. Secret files and ignored paths are excluded.
+func buildSkillPackage(skillPath string) ([]byte, []skillPackageFile, error) {
+	absPath, err := filepath.Abs(expandUserPath(skillPath))
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolve path: %w", err)
+	}
+	if absPath, err = filepath.EvalSymlinks(absPath); err != nil {
+		return nil, nil, fmt.Errorf("resolve path: %w", err)
+	}
+	ignore, err := loadSkillPackageIgnore(absPath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var sources []skillPackageSource
+	walkErr := filepath.WalkDir(absPath, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(absPath, path)
+		if relErr != nil {
+			return relErr
+		}
+		rel = filepath.ToSlash(rel)
+		if rel == "." {
+			return nil
+		}
+		if entry.IsDir() {
+			if shouldExcludeSkillPackagePath(rel, true, ignore) || isDefaultGeneratedSkillDir(entry.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			return infoErr
+		}
+		if !info.Mode().IsRegular() || shouldExcludeSkillPackagePath(rel, false, ignore) {
+			return nil
+		}
+		sources = append(sources, skillPackageSource{FullPath: path, RelPath: rel, Mode: info.Mode()})
+		return nil
+	})
+	if walkErr != nil {
+		return nil, nil, fmt.Errorf("walk skill directory: %w", walkErr)
+	}
+	sort.Slice(sources, func(i, j int) bool { return sources[i].RelPath < sources[j].RelPath })
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	files := make([]skillPackageFile, 0, len(sources))
+	for _, src := range sources {
+		data, readErr := os.ReadFile(src.FullPath)
+		if readErr != nil {
+			_ = zw.Close()
+			return nil, nil, fmt.Errorf("read %s: %w", src.RelPath, readErr)
+		}
+		header := &zip.FileHeader{Name: src.RelPath, Method: zip.Deflate, Modified: time.Unix(0, 0).UTC()}
+		header.SetMode(src.Mode.Perm())
+		w, hErr := zw.CreateHeader(header)
+		if hErr != nil {
+			_ = zw.Close()
+			return nil, nil, fmt.Errorf("create zip entry %s: %w", src.RelPath, hErr)
+		}
+		if _, wErr := w.Write(data); wErr != nil {
+			_ = zw.Close()
+			return nil, nil, fmt.Errorf("write zip entry %s: %w", src.RelPath, wErr)
+		}
+		sum := sha256.Sum256(data)
+		files = append(files, skillPackageFile{
+			Path:        src.RelPath,
+			Size:        int64(len(data)),
+			SHA256:      hex.EncodeToString(sum[:]),
+			ContentType: guessContentType(src.RelPath),
+		})
+	}
+	if err := zw.Close(); err != nil {
+		return nil, nil, fmt.Errorf("close skill package: %w", err)
+	}
+	return buf.Bytes(), files, nil
+}
+
+// --- frontmatter ---
+
+// parseFrontmatter extracts the YAML frontmatter (delimited by ---) from SKILL.md.
+func parseFrontmatter(content string) (map[string]any, error) {
+	content = strings.TrimSpace(content)
+	if !strings.HasPrefix(content, "---") {
+		return nil, fmt.Errorf("%s does not start with YAML frontmatter (---)", skillMarkdownFile)
+	}
+	rest := strings.TrimPrefix(content[3:], "\n")
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return nil, fmt.Errorf("%s frontmatter is not closed (missing second ---)", skillMarkdownFile)
+	}
+	var result map[string]any
+	if err := yaml.Unmarshal([]byte(rest[:end]), &result); err != nil {
+		return nil, fmt.Errorf("invalid YAML in frontmatter: %w", err)
+	}
+	if result == nil {
+		result = map[string]any{}
+	}
+	return result, nil
+}
+
+// parseAgentModelFlags parses repeated name=model overrides.
+func parseAgentModelFlags(flags []string) (map[string]string, error) {
+	if len(flags) == 0 {
+		return nil, nil
+	}
+	result := make(map[string]string, len(flags))
+	for _, f := range flags {
+		parts := strings.SplitN(f, "=", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return nil, fmt.Errorf("invalid --agent-model value %q: expected name=model", f)
+		}
+		result[parts[0]] = parts[1]
+	}
+	return result, nil
+}
+
+// --- ignore matching ---
+
+type skillPackageIgnoreMatcher struct {
+	patterns []string
+}
+
+const skillIgnoreFile = ".agentspanignore"
+
+func loadSkillPackageIgnore(skillRoot string) (skillPackageIgnoreMatcher, error) {
+	matcher := skillPackageIgnoreMatcher{}
+	data, err := os.ReadFile(filepath.Join(skillRoot, skillIgnoreFile))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return matcher, nil
+		}
+		return matcher, fmt.Errorf("read %s: %w", skillIgnoreFile, err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if line = strings.TrimSpace(line); line != "" && !strings.HasPrefix(line, "#") {
+			matcher.patterns = append(matcher.patterns, filepath.ToSlash(line))
+		}
+	}
+	return matcher, nil
+}
+
+func shouldExcludeSkillPackagePath(relPath string, isDir bool, matcher skillPackageIgnoreMatcher) bool {
+	relPath = filepath.ToSlash(strings.TrimPrefix(relPath, "./"))
+	if relPath == "" || relPath == "." {
+		return false
+	}
+	base := pathpkg.Base(relPath)
+	if base == skillIgnoreFile || isDefaultSecretSkillFile(base) {
+		return true
+	}
+	if isDir && isDefaultGeneratedSkillDir(base) {
+		return true
+	}
+	return matcher.matches(relPath, isDir)
+}
+
+func (m skillPackageIgnoreMatcher) matches(relPath string, isDir bool) bool {
+	for _, pattern := range m.patterns {
+		if skillIgnorePatternMatches(pattern, relPath, isDir) {
+			return true
+		}
+	}
+	return false
+}
+
+func skillIgnorePatternMatches(pattern, relPath string, isDir bool) bool {
+	pattern = filepath.ToSlash(strings.TrimSpace(pattern))
+	if pattern == "" || strings.HasPrefix(pattern, "!") {
+		return false
+	}
+	dirOnly := strings.HasSuffix(pattern, "/")
+	pattern = strings.TrimSuffix(pattern, "/")
+	if dirOnly && !isDir {
+		return relPath == pattern || strings.HasPrefix(relPath, pattern+"/")
+	}
+	if strings.Contains(pattern, "/") {
+		if ok, err := pathpkg.Match(pattern, relPath); err == nil && ok {
+			return true
+		}
+		return relPath == pattern || strings.HasPrefix(relPath, pattern+"/")
+	}
+	for _, part := range strings.Split(relPath, "/") {
+		if ok, err := pathpkg.Match(pattern, part); err == nil && ok {
+			return true
+		}
+	}
+	return false
+}
+
+func isDefaultGeneratedSkillDir(name string) bool {
+	switch name {
+	case ".git", "__pycache__", "node_modules", ".venv", "venv", ".tox", "dist", "build", "target", ".gradle", ".pytest_cache", ".mypy_cache":
+		return true
+	default:
+		return false
+	}
+}
+
+func isDefaultSecretSkillFile(name string) bool {
+	lower := strings.ToLower(name)
+	if lower == ".ds_store" || lower == ".env" || strings.HasPrefix(lower, ".env.") {
+		return true
+	}
+	switch lower {
+	case "id_rsa", "id_dsa", "id_ecdsa", "id_ed25519", "known_hosts":
+		return true
+	}
+	for _, suffix := range []string{".pem", ".key", ".p12", ".pfx", ".jks", ".keystore", ".crt", ".cer"} {
+		if strings.HasSuffix(lower, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func guessContentType(path string) string {
+	lower := strings.ToLower(path)
+	switch {
+	case strings.HasSuffix(lower, ".md"), strings.HasSuffix(lower, ".txt"):
+		return "text/plain"
+	case strings.HasSuffix(lower, ".json"):
+		return "application/json"
+	case strings.HasSuffix(lower, ".yaml"), strings.HasSuffix(lower, ".yml"):
+		return "application/yaml"
+	case strings.HasSuffix(lower, ".html"), strings.HasSuffix(lower, ".htm"):
+		return "text/html"
+	case strings.HasSuffix(lower, ".css"):
+		return "text/css"
+	case strings.HasSuffix(lower, ".js"), strings.HasSuffix(lower, ".mjs"):
+		return "text/javascript"
+	case strings.HasSuffix(lower, ".png"):
+		return "image/png"
+	case strings.HasSuffix(lower, ".jpg"), strings.HasSuffix(lower, ".jpeg"):
+		return "image/jpeg"
+	case strings.HasSuffix(lower, ".svg"):
+		return "image/svg+xml"
+	default:
+		return "application/octet-stream"
+	}
+}
+
+func init() {
+	skillRegisterCmd.Flags().StringVar(&skillRegisterVersion, "version", "", "Optional version label (defaults to a content hash on the server)")
+	skillRegisterCmd.Flags().StringVar(&skillRegisterModel, "model", "", "Orchestrator and default model")
+	skillRegisterCmd.Flags().StringArrayVar(&skillRegisterAgentModels, "agent-model", nil, "Sub-agent model override (name=model, repeatable)")
+	skillCmd.AddCommand(skillRegisterCmd)
+}

--- a/cmd/skill_register_test.go
+++ b/cmd/skill_register_test.go
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package cmd
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	full := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newSkillFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	writeFile(t, dir, "SKILL.md", "---\nname: summarize\ndescription: Summarize text\n---\nBody text\n")
+	writeFile(t, dir, "writer-agent.md", "agent body")
+	writeFile(t, dir, "scripts/run.py", "print('hi')")
+	writeFile(t, dir, "references/doc.md", "reference")
+	writeFile(t, dir, ".agentspanignore", "*.tmp\n")
+	writeFile(t, dir, "scratch.tmp", "ignored")
+	writeFile(t, dir, ".env", "SECRET=x")
+	writeFile(t, dir, "node_modules/dep/index.js", "junk")
+	return dir
+}
+
+func zipNames(t *testing.T, data []byte) map[string]bool {
+	t.Helper()
+	r, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("open zip: %v", err)
+	}
+	names := map[string]bool{}
+	for _, f := range r.File {
+		names[f.Name] = true
+	}
+	return names
+}
+
+func TestBuildSkillPackageIncludesAndExcludes(t *testing.T) {
+	dir := newSkillFixture(t)
+
+	pkg, files, err := buildSkillPackage(dir)
+	if err != nil {
+		t.Fatalf("buildSkillPackage: %v", err)
+	}
+	names := zipNames(t, pkg)
+
+	for _, want := range []string{"SKILL.md", "writer-agent.md", "scripts/run.py", "references/doc.md"} {
+		if !names[want] {
+			t.Errorf("expected %q in package, got %v", want, names)
+		}
+	}
+	for _, unwanted := range []string{"scratch.tmp", ".env", ".agentspanignore", "node_modules/dep/index.js"} {
+		if names[unwanted] {
+			t.Errorf("did not expect %q in package", unwanted)
+		}
+	}
+
+	// Manifest entries carry checksum + content type and match the included files.
+	if len(files) != len(names) {
+		t.Errorf("manifest has %d files, package has %d", len(files), len(names))
+	}
+	for _, f := range files {
+		if f.SHA256 == "" || f.ContentType == "" {
+			t.Errorf("file entry missing checksum/content-type: %+v", f)
+		}
+	}
+}
+
+func TestBuildSkillManifestReadsFrontmatter(t *testing.T) {
+	dir := newSkillFixture(t)
+	_, files, err := buildSkillPackage(dir)
+	if err != nil {
+		t.Fatalf("buildSkillPackage: %v", err)
+	}
+
+	raw, err := buildSkillManifest(dir, "v1", "openai/gpt-4o", []string{"writer=anthropic/claude"}, files)
+	if err != nil {
+		t.Fatalf("buildSkillManifest: %v", err)
+	}
+	var m skillManifest
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+	if m.Name != "summarize" || m.Description != "Summarize text" {
+		t.Errorf("manifest = %+v", m)
+	}
+	if m.Version != "v1" || m.Model != "openai/gpt-4o" || m.AgentModels["writer"] != "anthropic/claude" {
+		t.Errorf("manifest flags not applied: %+v", m)
+	}
+}
+
+func TestBuildSkillManifestRequiresName(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "SKILL.md", "---\ndescription: no name here\n---\nbody")
+	if _, err := buildSkillManifest(dir, "", "", nil, nil); err == nil {
+		t.Fatal("expected an error when SKILL.md has no name")
+	}
+}

--- a/cmd/skill_run.go
+++ b/cmd/skill_run.go
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/conductor-oss/conductor-cli/internal"
+	"github.com/conductor-oss/conductor-cli/internal/agent"
+	"github.com/conductor-oss/conductor-cli/internal/skillworker"
+)
+
+// Skill run/serve flag defaults.
+const (
+	defaultScriptTimeoutSeconds = 300
+	defaultScriptOutputLimit    = 10 << 20 // 10 MiB
+	defaultWorkspaceDir         = "."
+	defaultWorkspaceFileLimit   = 1 << 20 // 1 MiB
+)
+
+var (
+	// run only
+	skillRunModel       string
+	skillRunAgentModels []string
+	skillRunParams      []string
+	// run + serve
+	skillRunVersion         string
+	skillSearchPaths        []string
+	skillScriptTimeout      int
+	skillScriptOutputLimit  int
+	skillWorkspaceDir       string
+	skillNoWorkspace        bool
+	skillFileSystems        []string
+	skillWorkspaceFileLimit int
+)
+
+var skillRunCmd = &cobra.Command{
+	Use:   "run <path-or-name> <prompt>",
+	Short: "Run a local or registered skill and stream its output",
+	Long: `Run a local skill directory or a server-registered skill by name. The CLI
+starts local tool workers (read_skill_file, scripts, workspace tools), starts the
+skill agent on the server, and streams its execution. Workers run for the duration
+of the execution.`,
+	Args:         cobra.MinimumNArgs(2),
+	SilenceUsage: true,
+	RunE:         runSkillRun,
+}
+
+var skillServeCmd = &cobra.Command{
+	Use:   "serve <path-or-name>",
+	Short: "Start local tool workers for a skill without running it",
+	Long: `Start the local tool workers for a skill (read_skill_file, scripts, workspace
+tools) and block until interrupted. Use this to serve a skill's tools while it is
+run elsewhere (e.g. from the UI).`,
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE:         runSkillServe,
+}
+
+func runSkillRun(cmd *cobra.Command, args []string) error {
+	if skillRunModel == "" {
+		return fmt.Errorf("--model is required for skill run")
+	}
+	prompt := strings.Join(args[1:], " ")
+
+	agentModels, err := parseAgentModelFlags(skillRunAgentModels)
+	if err != nil {
+		return err
+	}
+	params, err := parseParamOverrides(skillRunParams)
+	if err != nil {
+		return err
+	}
+	ws, err := resolveSkillWorkspaceConfig()
+	if err != nil {
+		return err
+	}
+
+	dir, _, err := materializeSkill(cmd.Context(), internal.GetSkillService(), args[0], skillRunVersion)
+	if err != nil {
+		return err
+	}
+	cfg, local, err := BuildSkillPayload(dir, PayloadOptions{
+		Model:          skillRunModel,
+		AgentModels:    agentModels,
+		SearchPaths:    skillSearchPaths,
+		ParamOverrides: params,
+	})
+	if err != nil {
+		return err
+	}
+	cfg.Workspace = ws.WireConfig()
+
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("encode skill config: %w", err)
+	}
+
+	// One signal-aware context governs both the workers and the stream; cancelling
+	// it (Ctrl-C) stops everything. Workers are also cancelled when the execution
+	// ends normally.
+	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	workerCtx, cancelWorkers := context.WithCancel(ctx)
+	defer cancelWorkers()
+	startSkillWorkers(workerCtx, buildSkillWorkerRegistry(cfg, local, ws, scriptOptions(), skillWorkspaceFileLimit))
+
+	svc := internal.GetAgentService()
+	exec, err := svc.Run(ctx, agent.RunRequest{Framework: frameworkSkill, Definition: raw, Prompt: prompt})
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Skill: %s (Execution: %s)\n\n", exec.AgentName, exec.ID)
+
+	streamErr := svc.StreamExecution(ctx, exec.ID, "", terminalSink{})
+	cancelWorkers()
+	return streamErr
+}
+
+func runSkillServe(cmd *cobra.Command, args []string) error {
+	ws, err := resolveSkillWorkspaceConfig()
+	if err != nil {
+		return err
+	}
+	dir, _, err := materializeSkill(cmd.Context(), internal.GetSkillService(), args[0], skillRunVersion)
+	if err != nil {
+		return err
+	}
+	cfg, local, err := BuildSkillPayload(dir, PayloadOptions{SearchPaths: skillSearchPaths})
+	if err != nil {
+		return err
+	}
+
+	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	startSkillWorkers(ctx, buildSkillWorkerRegistry(cfg, local, ws, scriptOptions(), skillWorkspaceFileLimit))
+
+	fmt.Printf("Serving workers for skill %s. Press Ctrl-C to stop.\n", local.SkillName)
+	<-ctx.Done()
+	return nil
+}
+
+// scriptOptions builds the script-execution bounds from the shared flags.
+func scriptOptions() skillworker.ScriptOptions {
+	return skillworker.ScriptOptions{
+		Timeout:     time.Duration(skillScriptTimeout) * time.Second,
+		OutputLimit: skillScriptOutputLimit,
+	}
+}
+
+// startSkillWorkers launches one polling worker goroutine per registered task type.
+// They run until ctx is cancelled.
+func startSkillWorkers(ctx context.Context, registry map[string]skillworker.ToolHandler) {
+	taskClient := internal.GetTaskClient()
+	for taskType, handler := range registry {
+		w := skillworker.NewWorker(skillworker.NewConductorRunner(taskClient))
+		go w.Run(ctx, taskType, handler)
+	}
+}
+
+// buildSkillWorkerRegistry maps every "{skillName}__{tool}" task type the skill (and
+// its resolved cross-skills) needs to the handler that serves it locally.
+func buildSkillWorkerRegistry(cfg SkillConfig, local LocalContext, ws skillworker.WorkspaceConfig, opts skillworker.ScriptOptions, fileLimit int) map[string]skillworker.ToolHandler {
+	reg := map[string]skillworker.ToolHandler{}
+	addSkillWorkerHandlers(reg, cfg, local, ws, opts, fileLimit)
+	return reg
+}
+
+func addSkillWorkerHandlers(reg map[string]skillworker.ToolHandler, cfg SkillConfig, local LocalContext, ws skillworker.WorkspaceConfig, opts skillworker.ScriptOptions, fileLimit int) {
+	name := local.SkillName
+	if name == "" {
+		return
+	}
+	reg[skillworker.TaskType(name, skillworker.ToolReadSkillFile)] = skillworker.NewReadSkillFileHandler(local.SkillDir, cfg.ResourceFiles, local.Sections)
+	for tool, info := range cfg.Scripts {
+		scriptPath := filepath.Join(local.SkillDir, scriptsDirName, info.Filename)
+		reg[skillworker.TaskType(name, tool)] = skillworker.NewScriptHandler(scriptPath, info.Language, ws, opts)
+	}
+	if ws.Enabled {
+		reg[skillworker.TaskType(name, skillworker.ToolListWorkspace)] = skillworker.NewListWorkspaceFilesHandler(ws)
+		reg[skillworker.TaskType(name, skillworker.ToolReadWorkspaceFile)] = skillworker.NewReadWorkspaceFileHandler(ws, fileLimit)
+		reg[skillworker.TaskType(name, skillworker.ToolSearchWorkspace)] = skillworker.NewSearchWorkspaceHandler(ws, fileLimit)
+		reg[skillworker.TaskType(name, skillworker.ToolGitStatus)] = skillworker.NewGitStatusHandler(ws, fileLimit)
+		reg[skillworker.TaskType(name, skillworker.ToolGitDiff)] = skillworker.NewGitDiffHandler(ws, fileLimit)
+	}
+	for refName, refCfg := range cfg.CrossSkillRefs {
+		if refLocal, ok := local.CrossSkills[refName]; ok {
+			addSkillWorkerHandlers(reg, refCfg, refLocal, ws, opts, fileLimit)
+		}
+	}
+}
+
+// resolveSkillWorkspaceConfig builds the workspace configuration from the shared
+// flags. Flag parsing stays in the cmd layer; skillworker validates each root.
+func resolveSkillWorkspaceConfig() (skillworker.WorkspaceConfig, error) {
+	cfg := skillworker.WorkspaceConfig{}
+	seen := map[string]bool{}
+	addRoot := func(name, pathValue, kind string) error {
+		root, err := skillworker.NewWorkspaceRoot(name, expandUserPath(pathValue), kind)
+		if err != nil {
+			return err
+		}
+		if seen[root.Name] {
+			return fmt.Errorf("duplicate filesystem root %q", root.Name)
+		}
+		seen[root.Name] = true
+		cfg.Roots = append(cfg.Roots, root)
+		return nil
+	}
+
+	if !skillNoWorkspace {
+		workspacePath := skillWorkspaceDir
+		if strings.TrimSpace(workspacePath) == "" {
+			workspacePath = defaultWorkspaceDir
+		}
+		if err := addRoot(skillworker.KindWorkspace, workspacePath, skillworker.KindWorkspace); err != nil {
+			return cfg, err
+		}
+	}
+	for _, spec := range skillFileSystems {
+		name, pathValue, ok := strings.Cut(spec, "=")
+		if !ok || strings.TrimSpace(name) == "" || strings.TrimSpace(pathValue) == "" {
+			return cfg, fmt.Errorf("invalid --filesystem value %q: expected name=path", spec)
+		}
+		if err := addRoot(strings.TrimSpace(name), strings.TrimSpace(pathValue), skillworker.KindFilesystem); err != nil {
+			return cfg, err
+		}
+	}
+	cfg.Enabled = len(cfg.Roots) > 0
+	return cfg, nil
+}
+
+// parseParamOverrides parses repeated --param key=value flags into typed values.
+func parseParamOverrides(flags []string) (map[string]ParamValue, error) {
+	if len(flags) == 0 {
+		return nil, nil
+	}
+	result := make(map[string]ParamValue, len(flags))
+	for _, f := range flags {
+		name, value, ok := strings.Cut(f, "=")
+		if !ok || name == "" {
+			return nil, fmt.Errorf("invalid --param value %q: expected key=value", f)
+		}
+		result[name] = parseParamValue(value)
+	}
+	return result, nil
+}
+
+// parseParamValue coerces "true"/"false" to a bool, keeping everything else as a
+// string (faithful to the original).
+func parseParamValue(value string) ParamValue {
+	switch strings.ToLower(value) {
+	case "true":
+		return rawParamValue(true)
+	case "false":
+		return rawParamValue(false)
+	default:
+		return rawParamValue(value)
+	}
+}
+
+func init() {
+	skillRunCmd.Flags().StringVar(&skillRunModel, "model", "", "Orchestrator and default model (required)")
+	skillRunCmd.Flags().StringArrayVar(&skillRunAgentModels, "agent-model", nil, "Sub-agent model override (name=model, repeatable)")
+	skillRunCmd.Flags().StringArrayVar(&skillRunParams, "param", nil, "Skill parameter override (key=value, repeatable)")
+	addSkillWorkerFlags(skillRunCmd)
+
+	addSkillWorkerFlags(skillServeCmd)
+
+	skillCmd.AddCommand(skillRunCmd, skillServeCmd)
+}
+
+// addSkillWorkerFlags binds the flags shared by run and serve.
+func addSkillWorkerFlags(cmd *cobra.Command) {
+	cmd.Flags().StringArrayVar(&skillSearchPaths, "search-path", nil, "Cross-skill search directory (repeatable)")
+	cmd.Flags().StringVar(&skillRunVersion, "version", "", "Registered skill version or checksum prefix")
+	cmd.Flags().IntVar(&skillScriptTimeout, "script-timeout", defaultScriptTimeoutSeconds, "Skill script timeout in seconds")
+	cmd.Flags().IntVar(&skillScriptOutputLimit, "script-output-limit", defaultScriptOutputLimit, "Maximum bytes captured from skill script output")
+	cmd.Flags().StringVar(&skillWorkspaceDir, "workspace", defaultWorkspaceDir, "Workspace directory exposed to workspace tools")
+	cmd.Flags().BoolVar(&skillNoWorkspace, "no-workspace", false, "Disable exposing the current workspace")
+	cmd.Flags().StringArrayVar(&skillFileSystems, "filesystem", nil, "Additional read-only filesystem root name=path (repeatable)")
+	cmd.Flags().IntVar(&skillWorkspaceFileLimit, "workspace-file-limit", defaultWorkspaceFileLimit, "Maximum bytes returned by workspace file tools")
+}

--- a/cmd/skill_run_test.go
+++ b/cmd/skill_run_test.go
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package cmd
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/conductor-oss/conductor-cli/internal/skill"
+	"github.com/conductor-oss/conductor-cli/internal/skillworker"
+)
+
+func TestResolveSkillWorkspaceConfig(t *testing.T) {
+	wsDir := t.TempDir()
+	extraDir := t.TempDir()
+
+	skillNoWorkspace = false
+	skillWorkspaceDir = wsDir
+	skillFileSystems = []string{"docs=" + extraDir}
+	t.Cleanup(func() { skillFileSystems = nil })
+
+	cfg, err := resolveSkillWorkspaceConfig()
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if !cfg.Enabled || len(cfg.Roots) != 2 {
+		t.Fatalf("cfg = %+v", cfg)
+	}
+	if _, ok := cfg.Root("workspace"); !ok {
+		t.Error("missing default workspace root")
+	}
+	if _, ok := cfg.Root("docs"); !ok {
+		t.Error("missing named filesystem root")
+	}
+
+	// --no-workspace with no filesystems disables the workspace.
+	skillNoWorkspace = true
+	skillFileSystems = nil
+	cfg, err = resolveSkillWorkspaceConfig()
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if cfg.Enabled {
+		t.Errorf("expected disabled workspace, got %+v", cfg)
+	}
+	skillNoWorkspace = false
+
+	// Invalid --filesystem spec is rejected.
+	skillFileSystems = []string{"bad-spec"}
+	if _, err := resolveSkillWorkspaceConfig(); err == nil {
+		t.Error("expected an error for a malformed --filesystem value")
+	}
+	skillFileSystems = nil
+}
+
+func TestParseParamOverrides(t *testing.T) {
+	out, err := parseParamOverrides([]string{"tone=terse", "verbose=true", "keep=false"})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if out["tone"].format() != "terse" {
+		t.Errorf("tone = %q", out["tone"].format())
+	}
+	if out["verbose"].format() != "true" {
+		t.Errorf("verbose = %q", out["verbose"].format())
+	}
+	// bool values marshal as JSON bools, not strings.
+	b, _ := json.Marshal(out["verbose"])
+	if string(b) != "true" {
+		t.Errorf("verbose JSON = %s", b)
+	}
+	if _, err := parseParamOverrides([]string{"noequals"}); err == nil {
+		t.Error("expected an error for a param without '='")
+	}
+}
+
+func TestBuildSkillWorkerRegistry(t *testing.T) {
+	cfg := SkillConfig{
+		ResourceFiles: []string{"notes.txt"},
+		Scripts:       map[string]ScriptInfo{"greet": {Filename: "greet.sh", Language: skillworker.LangBash}},
+		CrossSkillRefs: map[string]SkillConfig{
+			"helper": {Scripts: map[string]ScriptInfo{"aid": {Filename: "aid.sh", Language: skillworker.LangBash}}},
+		},
+	}
+	local := LocalContext{
+		SkillName:   "main",
+		SkillDir:    t.TempDir(),
+		Sections:    map[string]string{"intro": "## Intro"},
+		CrossSkills: map[string]LocalContext{"helper": {SkillName: "helper", SkillDir: t.TempDir()}},
+	}
+	ws := skillworker.WorkspaceConfig{Enabled: true, Roots: []skillworker.WorkspaceRoot{{Name: "workspace", Path: t.TempDir(), Kind: skillworker.KindWorkspace}}}
+
+	reg := buildSkillWorkerRegistry(cfg, local, ws, skillworker.ScriptOptions{}, 1<<20)
+
+	for _, taskType := range []string{
+		"main__read_skill_file", "main__greet",
+		"main__list_workspace_files", "main__read_workspace_file",
+		"main__search_workspace", "main__git_status", "main__git_diff",
+		"helper__read_skill_file", "helper__aid",
+	} {
+		if _, ok := reg[taskType]; !ok {
+			t.Errorf("registry missing task type %q (have %v)", taskType, registryKeys(reg))
+		}
+	}
+}
+
+func TestBuildSkillWorkerRegistryNoWorkspace(t *testing.T) {
+	cfg := SkillConfig{Scripts: map[string]ScriptInfo{"greet": {Filename: "greet.sh", Language: skillworker.LangBash}}}
+	local := LocalContext{SkillName: "main", SkillDir: t.TempDir()}
+	reg := buildSkillWorkerRegistry(cfg, local, skillworker.WorkspaceConfig{}, skillworker.ScriptOptions{}, 1<<20)
+
+	if _, ok := reg["main__list_workspace_files"]; ok {
+		t.Error("workspace tools should not be registered when the workspace is disabled")
+	}
+	if _, ok := reg["main__read_skill_file"]; !ok {
+		t.Error("read_skill_file should always be registered")
+	}
+}
+
+// ---- materialize ----
+
+type fakeSkillService struct {
+	detail    skill.Detail
+	pkg       []byte
+	downloads int
+}
+
+func (f *fakeSkillService) List(context.Context, bool) ([]skill.Summary, error) { return nil, nil }
+func (f *fakeSkillService) Get(context.Context, string, string) (skill.Detail, error) {
+	return f.detail, nil
+}
+func (f *fakeSkillService) DownloadPackage(context.Context, string, string) ([]byte, error) {
+	f.downloads++
+	return f.pkg, nil
+}
+func (f *fakeSkillService) Register(context.Context, json.RawMessage, []byte) (skill.Detail, error) {
+	return skill.Detail{}, nil
+}
+func (f *fakeSkillService) Delete(context.Context, string, string) error { return nil }
+
+func TestMaterializeLocalDirectory(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: x\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, detail, err := materializeSkill(context.Background(), &fakeSkillService{}, dir, "")
+	if err != nil {
+		t.Fatalf("materialize local: %v", err)
+	}
+	if got != dir || detail != nil {
+		t.Errorf("local dir should be used as-is: got=%q detail=%v", got, detail)
+	}
+}
+
+func TestMaterializeRegisteredSkillCaches(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // isolate the config-home cache
+
+	pkg := skillZip(t, map[string]string{"SKILL.md": "---\nname: reg\n---\nbody"})
+	sum := sha256.Sum256(pkg)
+	svc := &fakeSkillService{
+		detail: skill.Detail{Name: "reg", Version: "1", Checksum: hex.EncodeToString(sum[:])},
+		pkg:    pkg,
+	}
+
+	dir, detail, err := materializeSkill(context.Background(), svc, "reg", "")
+	if err != nil {
+		t.Fatalf("materialize registered: %v", err)
+	}
+	if detail == nil || detail.Name != "reg" {
+		t.Fatalf("detail = %+v", detail)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "SKILL.md")); err != nil {
+		t.Errorf("cached skill missing SKILL.md: %v", err)
+	}
+	if svc.downloads != 1 {
+		t.Errorf("expected 1 download, got %d", svc.downloads)
+	}
+
+	// Second call hits the cache — no additional download.
+	dir2, _, err := materializeSkill(context.Background(), svc, "reg", "")
+	if err != nil {
+		t.Fatalf("materialize (cache hit): %v", err)
+	}
+	if dir2 != dir {
+		t.Errorf("cache-hit dir = %q, want %q", dir2, dir)
+	}
+	if svc.downloads != 1 {
+		t.Errorf("cache hit re-downloaded: downloads = %d", svc.downloads)
+	}
+}
+
+func TestMaterializeChecksumMismatch(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	svc := &fakeSkillService{
+		detail: skill.Detail{Name: "reg", Version: "1", Checksum: "deadbeef"},
+		pkg:    skillZip(t, map[string]string{"SKILL.md": "---\nname: reg\n---\n"}),
+	}
+	if _, _, err := materializeSkill(context.Background(), svc, "reg", ""); err == nil {
+		t.Fatal("expected a checksum mismatch error")
+	}
+}
+
+// skillZip builds an in-memory skill package zip from path→content.
+func skillZip(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, content := range files {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func registryKeys(reg map[string]skillworker.ToolHandler) []string {
+	keys := make([]string, 0, len(reg))
+	for k := range reg {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/cmd/transport.go
+++ b/cmd/transport.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package cmd
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/conductor-sdk/conductor-go/sdk/settings"
+
+	"github.com/conductor-oss/conductor-cli/internal/transport"
+)
+
+// sdkTokenManager is the subset of the conductor-go TokenManager interface that the
+// CLI's token managers implement (ConfigTokenManager and *CachedTokenManager). It
+// mints or refreshes the JWT used for X-Authorization.
+type sdkTokenManager interface {
+	RefreshToken(*settings.HttpSettings, *http.Client) (string, error)
+}
+
+// tokenProvider adapts a conductor-go token manager to transport.TokenProvider so
+// that agent and skill traffic reuses exactly the same JWT — including refresh and
+// caching — as the conductor-go SDK client.
+type tokenProvider struct {
+	manager      sdkTokenManager
+	httpSettings *settings.HttpSettings
+	httpClient   *http.Client
+}
+
+// newTokenProvider wraps a token manager. Pass nil to mean anonymous access.
+func newTokenProvider(m sdkTokenManager, hs *settings.HttpSettings) transport.TokenProvider {
+	if m == nil {
+		return nil
+	}
+	return tokenProvider{manager: m, httpSettings: hs, httpClient: &http.Client{}}
+}
+
+func (p tokenProvider) Token(context.Context) (string, error) {
+	return p.manager.RefreshToken(p.httpSettings, p.httpClient)
+}

--- a/internal/agent/client.go
+++ b/internal/agent/client.go
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/conductor-oss/conductor-cli/internal/transport"
+)
+
+// Endpoint paths. These are fixed by the server API contract, so they are named
+// constants rather than configuration — but never inline literals at call sites.
+// Paths are relative to the transport BaseURL, which already includes the "/api"
+// prefix (see cmd/root.go) — mirroring the conductor-go SDK, whose base is also
+// ".../api" and whose resource paths omit it. Do not re-add "/api" here.
+const (
+	pathAgents     = "/agent"                  // base; "/{name}" appended
+	pathStart      = "/agent/start"            //
+	pathDeploy     = "/agent/deploy"           // publish/activate without starting
+	pathCompile    = "/agent/compile"          //
+	pathList       = "/agent/list"             //
+	pathExecutions = "/agent/executions"       // base; "/{id}" appended
+	pathPrune      = "/agent/executions/prune" //
+	pathStatusFmt  = "/agent/%s/status"        // execution id
+	pathRespondFmt = "/agent/%s/respond"       // execution id
+	pathStreamFmt  = "/agent/stream/%s"        // execution id (SSE; used by Stream)
+)
+
+// Query-parameter keys and fixed values used by the agent endpoints.
+const (
+	queryVersion       = "version"
+	queryStart         = "start"
+	querySize          = "size"
+	querySort          = "sort"
+	queryAgentName     = "agentName"
+	queryStatus        = "status"
+	queryFreeText      = "freeText"
+	queryOlderThanDays = "olderThanDays"
+	queryArchiveTasks  = "archiveTasks"
+	sortExecutions     = "startTime:DESC"
+	valueTrue          = "true"
+)
+
+// Streaming (SSE) constants.
+const (
+	sseChannelBuffer  = 100
+	headerAccept      = "Accept"
+	headerLastEventID = "Last-Event-ID"
+	mimeEventStream   = "text/event-stream"
+)
+
+// Client is the transport boundary for agent endpoints. It returns domain types or
+// raw JSON for free-form payloads — never *http.Response or transport types.
+type Client interface {
+	Run(ctx context.Context, req RunRequest) (Execution, error)
+	Deploy(ctx context.Context, framework string, rawConfig json.RawMessage) (DeployResult, error)
+	Stream(ctx context.Context, executionID, lastEventID string) (<-chan SSEEvent, <-chan error)
+	List(ctx context.Context) ([]AgentSummary, error)
+	Get(ctx context.Context, name string, version *int) (json.RawMessage, error)
+	Delete(ctx context.Context, name string, version *int) error
+	Compile(ctx context.Context, def json.RawMessage) (json.RawMessage, error)
+	SearchExecutions(ctx context.Context, filter ExecutionFilter) (ExecutionPage, error)
+	GetExecution(ctx context.Context, id string) (json.RawMessage, error)
+	Status(ctx context.Context, id string) (json.RawMessage, error)
+	Respond(ctx context.Context, id string, resp HumanResponse) error
+	Prune(ctx context.Context, req PruneRequest) (PruneResult, error)
+}
+
+// NewClient returns a Client backed by the shared transport.
+func NewClient(t transport.Config) Client {
+	return &restClient{t: t}
+}
+
+type restClient struct {
+	t transport.Config
+}
+
+// Wire DTOs — private to the client so the JSON shape never leaks across a boundary.
+
+type startRequest struct {
+	AgentConfig json.RawMessage `json:"agentConfig,omitempty"`
+	Prompt      string          `json:"prompt,omitempty"`
+	SessionID   string          `json:"sessionId,omitempty"`
+}
+
+type frameworkRequest struct {
+	Framework string          `json:"framework"`
+	RawConfig json.RawMessage `json:"rawConfig,omitempty"`
+	Prompt    string          `json:"prompt,omitempty"`
+	SessionID string          `json:"sessionId,omitempty"`
+}
+
+type startResponse struct {
+	ExecutionID string `json:"executionId"`
+	AgentName   string `json:"agentName"`
+}
+
+type deployRequest struct {
+	Framework string          `json:"framework"`
+	RawConfig json.RawMessage `json:"rawConfig,omitempty"`
+}
+
+type deployResponse struct {
+	AgentName       string   `json:"agentName"`
+	RequiredWorkers []string `json:"requiredWorkers,omitempty"`
+}
+
+type respondRequest struct {
+	Approved bool   `json:"approved"`
+	Reason   string `json:"reason,omitempty"`
+	Message  string `json:"message,omitempty"`
+}
+
+type pruneResponse struct {
+	Deleted int `json:"deleted"`
+}
+
+func (c *restClient) Run(ctx context.Context, req RunRequest) (Execution, error) {
+	var body any
+	if req.Framework != "" {
+		body = frameworkRequest{Framework: req.Framework, RawConfig: req.Definition, Prompt: req.Prompt, SessionID: req.SessionID}
+	} else {
+		body = startRequest{AgentConfig: req.Definition, Prompt: req.Prompt, SessionID: req.SessionID}
+	}
+	var sr startResponse
+	if err := c.t.DoJSON(ctx, http.MethodPost, pathStart, body, &sr); err != nil {
+		return Execution{}, err
+	}
+	return Execution{ID: sr.ExecutionID, AgentName: sr.AgentName}, nil
+}
+
+// Deploy publishes and activates a framework agent definition without starting an
+// execution — the non-interactive counterpart of Run. The definition is opaque
+// bytes assembled by the caller; the framework marker selects the server envelope.
+func (c *restClient) Deploy(ctx context.Context, framework string, rawConfig json.RawMessage) (DeployResult, error) {
+	body := deployRequest{Framework: framework, RawConfig: rawConfig}
+	var dr deployResponse
+	if err := c.t.DoJSON(ctx, http.MethodPost, pathDeploy, body, &dr); err != nil {
+		return DeployResult{}, err
+	}
+	return DeployResult{AgentName: dr.AgentName, RequiredWorkers: dr.RequiredWorkers}, nil
+}
+
+// Stream opens an SSE connection for an execution and returns an event channel and
+// a single-error channel. The caller ranges the events; when it closes, the error
+// channel carries the terminal error (nil on a clean end). Cancelling ctx ends the
+// stream — that surfaces as a context error which the service treats as a clean stop.
+func (c *restClient) Stream(ctx context.Context, executionID, lastEventID string) (<-chan SSEEvent, <-chan error) {
+	events := make(chan SSEEvent, sseChannelBuffer)
+	errc := make(chan error, 1)
+	go func() {
+		defer close(errc)
+		defer close(events)
+
+		header := http.Header{}
+		header.Set(headerAccept, mimeEventStream)
+		if lastEventID != "" {
+			header.Set(headerLastEventID, lastEventID)
+		}
+		resp, err := c.t.Do(ctx, http.MethodGet, fmt.Sprintf(pathStreamFmt, url.PathEscape(executionID)), nil, header)
+		if err != nil {
+			errc <- err
+			return
+		}
+		defer resp.Body.Close()
+		errc <- parseSSE(resp.Body, events)
+	}()
+	return events, errc
+}
+
+func (c *restClient) List(ctx context.Context) ([]AgentSummary, error) {
+	var out []AgentSummary
+	if err := c.t.DoJSON(ctx, http.MethodGet, pathList, nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *restClient) Get(ctx context.Context, name string, version *int) (json.RawMessage, error) {
+	var out json.RawMessage
+	if err := c.t.DoJSON(ctx, http.MethodGet, agentPath(name, version), nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *restClient) Delete(ctx context.Context, name string, version *int) error {
+	return c.t.DoJSON(ctx, http.MethodDelete, agentPath(name, version), nil, nil)
+}
+
+func (c *restClient) Compile(ctx context.Context, def json.RawMessage) (json.RawMessage, error) {
+	var out json.RawMessage
+	if err := c.t.DoJSON(ctx, http.MethodPost, pathCompile, def, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *restClient) SearchExecutions(ctx context.Context, filter ExecutionFilter) (ExecutionPage, error) {
+	q := url.Values{}
+	q.Set(queryStart, strconv.Itoa(filter.Start))
+	q.Set(querySize, strconv.Itoa(filter.Size))
+	q.Set(querySort, sortExecutions)
+	if filter.AgentName != "" {
+		q.Set(queryAgentName, filter.AgentName)
+	}
+	if filter.Status != "" {
+		q.Set(queryStatus, filter.Status)
+	}
+	if filter.FreeText != "" {
+		q.Set(queryFreeText, filter.FreeText)
+	}
+	var page ExecutionPage
+	if err := c.t.DoJSON(ctx, http.MethodGet, pathExecutions+"?"+q.Encode(), nil, &page); err != nil {
+		return ExecutionPage{}, err
+	}
+	return page, nil
+}
+
+func (c *restClient) GetExecution(ctx context.Context, id string) (json.RawMessage, error) {
+	var out json.RawMessage
+	if err := c.t.DoJSON(ctx, http.MethodGet, pathExecutions+"/"+url.PathEscape(id), nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *restClient) Status(ctx context.Context, id string) (json.RawMessage, error) {
+	var out json.RawMessage
+	if err := c.t.DoJSON(ctx, http.MethodGet, fmt.Sprintf(pathStatusFmt, url.PathEscape(id)), nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *restClient) Respond(ctx context.Context, id string, resp HumanResponse) error {
+	body := respondRequest{Approved: resp.Approved, Reason: resp.Reason, Message: resp.Message}
+	return c.t.DoJSON(ctx, http.MethodPost, fmt.Sprintf(pathRespondFmt, url.PathEscape(id)), body, nil)
+}
+
+func (c *restClient) Prune(ctx context.Context, req PruneRequest) (PruneResult, error) {
+	q := url.Values{}
+	q.Set(queryOlderThanDays, strconv.Itoa(req.OlderThanDays))
+	if req.Archive {
+		q.Set(queryArchiveTasks, valueTrue)
+	}
+	var pr pruneResponse
+	if err := c.t.DoJSON(ctx, http.MethodPost, pathPrune+"?"+q.Encode(), nil, &pr); err != nil {
+		return PruneResult{}, err
+	}
+	return PruneResult{Removed: pr.Deleted}, nil
+}
+
+// agentPath builds the /agent/{name} path (relative to the /api BaseURL) with an
+// optional ?version=N.
+func agentPath(name string, version *int) string {
+	p := pathAgents + "/" + url.PathEscape(name)
+	if version != nil {
+		q := url.Values{}
+		q.Set(queryVersion, strconv.Itoa(*version))
+		p += "?" + q.Encode()
+	}
+	return p
+}

--- a/internal/agent/client.go
+++ b/internal/agent/client.go
@@ -16,7 +16,9 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -68,6 +70,7 @@ const (
 // Client is the transport boundary for agent endpoints. It returns domain types or
 // raw JSON for free-form payloads — never *http.Response or transport types.
 type Client interface {
+	CheckSupported(ctx context.Context) error
 	Run(ctx context.Context, req RunRequest) (Execution, error)
 	Deploy(ctx context.Context, framework string, rawConfig json.RawMessage) (DeployResult, error)
 	Stream(ctx context.Context, executionID, lastEventID string) (<-chan SSEEvent, <-chan error)
@@ -89,6 +92,50 @@ func NewClient(t transport.Config) Client {
 
 type restClient struct {
 	t transport.Config
+}
+
+const unsupportedAPIMessage = "Agents API is not available on this Conductor server. Update to the latest version of Conductor with Agents enabled."
+
+// do and doJSON preserve normal API errors, but turn a missing Agents API into an
+// actionable compatibility error. A 404 from a resource endpoint is ambiguous: it
+// can mean either "this agent/execution does not exist" or "this server predates the
+// Agents API". In that case we probe the list endpoint and only show the upgrade
+// guidance when the list endpoint is missing too.
+func (c *restClient) do(ctx context.Context, method, path string, body io.Reader, header http.Header) (*http.Response, error) {
+	resp, err := c.t.Do(ctx, method, path, body, header)
+	if err != nil {
+		return nil, c.agentAPIError(ctx, path, err)
+	}
+	return resp, nil
+}
+
+func (c *restClient) doJSON(ctx context.Context, method, path string, reqBody, respBody any) error {
+	err := c.t.DoJSON(ctx, method, path, reqBody, respBody)
+	if err != nil {
+		return c.agentAPIError(ctx, path, err)
+	}
+	return nil
+}
+
+func (c *restClient) agentAPIError(ctx context.Context, path string, err error) error {
+	var apiErr *transport.APIError
+	if !errors.As(err, &apiErr) || apiErr.Status != http.StatusNotFound {
+		return err
+	}
+	if path == pathList {
+		return errors.New(unsupportedAPIMessage)
+	}
+
+	resp, probeErr := c.t.Do(ctx, http.MethodGet, pathList, nil, nil)
+	if resp != nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}
+	var probeAPIErr *transport.APIError
+	if errors.As(probeErr, &probeAPIErr) && probeAPIErr.Status == http.StatusNotFound {
+		return errors.New(unsupportedAPIMessage)
+	}
+	return err
 }
 
 // Wire DTOs — private to the client so the JSON shape never leaks across a boundary.
@@ -131,6 +178,13 @@ type pruneResponse struct {
 	Deleted int `json:"deleted"`
 }
 
+// CheckSupported verifies that the connected server exposes the Agents API. It is
+// used by commands that delegate their actual request to another process and would
+// otherwise bypass this client's compatibility-error handling.
+func (c *restClient) CheckSupported(ctx context.Context) error {
+	return c.doJSON(ctx, http.MethodGet, pathList, nil, nil)
+}
+
 func (c *restClient) Run(ctx context.Context, req RunRequest) (Execution, error) {
 	var body any
 	if req.Framework != "" {
@@ -139,7 +193,7 @@ func (c *restClient) Run(ctx context.Context, req RunRequest) (Execution, error)
 		body = startRequest{AgentConfig: req.Definition, Prompt: req.Prompt, SessionID: req.SessionID}
 	}
 	var sr startResponse
-	if err := c.t.DoJSON(ctx, http.MethodPost, pathStart, body, &sr); err != nil {
+	if err := c.doJSON(ctx, http.MethodPost, pathStart, body, &sr); err != nil {
 		return Execution{}, err
 	}
 	return Execution{ID: sr.ExecutionID, AgentName: sr.AgentName}, nil
@@ -151,7 +205,7 @@ func (c *restClient) Run(ctx context.Context, req RunRequest) (Execution, error)
 func (c *restClient) Deploy(ctx context.Context, framework string, rawConfig json.RawMessage) (DeployResult, error) {
 	body := deployRequest{Framework: framework, RawConfig: rawConfig}
 	var dr deployResponse
-	if err := c.t.DoJSON(ctx, http.MethodPost, pathDeploy, body, &dr); err != nil {
+	if err := c.doJSON(ctx, http.MethodPost, pathDeploy, body, &dr); err != nil {
 		return DeployResult{}, err
 	}
 	return DeployResult{AgentName: dr.AgentName, RequiredWorkers: dr.RequiredWorkers}, nil
@@ -173,7 +227,7 @@ func (c *restClient) Stream(ctx context.Context, executionID, lastEventID string
 		if lastEventID != "" {
 			header.Set(headerLastEventID, lastEventID)
 		}
-		resp, err := c.t.Do(ctx, http.MethodGet, fmt.Sprintf(pathStreamFmt, url.PathEscape(executionID)), nil, header)
+		resp, err := c.do(ctx, http.MethodGet, fmt.Sprintf(pathStreamFmt, url.PathEscape(executionID)), nil, header)
 		if err != nil {
 			errc <- err
 			return
@@ -186,7 +240,7 @@ func (c *restClient) Stream(ctx context.Context, executionID, lastEventID string
 
 func (c *restClient) List(ctx context.Context) ([]AgentSummary, error) {
 	var out []AgentSummary
-	if err := c.t.DoJSON(ctx, http.MethodGet, pathList, nil, &out); err != nil {
+	if err := c.doJSON(ctx, http.MethodGet, pathList, nil, &out); err != nil {
 		return nil, err
 	}
 	return out, nil
@@ -194,19 +248,19 @@ func (c *restClient) List(ctx context.Context) ([]AgentSummary, error) {
 
 func (c *restClient) Get(ctx context.Context, name string, version *int) (json.RawMessage, error) {
 	var out json.RawMessage
-	if err := c.t.DoJSON(ctx, http.MethodGet, agentPath(name, version), nil, &out); err != nil {
+	if err := c.doJSON(ctx, http.MethodGet, agentPath(name, version), nil, &out); err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
 func (c *restClient) Delete(ctx context.Context, name string, version *int) error {
-	return c.t.DoJSON(ctx, http.MethodDelete, agentPath(name, version), nil, nil)
+	return c.doJSON(ctx, http.MethodDelete, agentPath(name, version), nil, nil)
 }
 
 func (c *restClient) Compile(ctx context.Context, def json.RawMessage) (json.RawMessage, error) {
 	var out json.RawMessage
-	if err := c.t.DoJSON(ctx, http.MethodPost, pathCompile, def, &out); err != nil {
+	if err := c.doJSON(ctx, http.MethodPost, pathCompile, def, &out); err != nil {
 		return nil, err
 	}
 	return out, nil
@@ -227,7 +281,7 @@ func (c *restClient) SearchExecutions(ctx context.Context, filter ExecutionFilte
 		q.Set(queryFreeText, filter.FreeText)
 	}
 	var page ExecutionPage
-	if err := c.t.DoJSON(ctx, http.MethodGet, pathExecutions+"?"+q.Encode(), nil, &page); err != nil {
+	if err := c.doJSON(ctx, http.MethodGet, pathExecutions+"?"+q.Encode(), nil, &page); err != nil {
 		return ExecutionPage{}, err
 	}
 	return page, nil
@@ -235,7 +289,7 @@ func (c *restClient) SearchExecutions(ctx context.Context, filter ExecutionFilte
 
 func (c *restClient) GetExecution(ctx context.Context, id string) (json.RawMessage, error) {
 	var out json.RawMessage
-	if err := c.t.DoJSON(ctx, http.MethodGet, pathExecutions+"/"+url.PathEscape(id), nil, &out); err != nil {
+	if err := c.doJSON(ctx, http.MethodGet, pathExecutions+"/"+url.PathEscape(id), nil, &out); err != nil {
 		return nil, err
 	}
 	return out, nil
@@ -243,7 +297,7 @@ func (c *restClient) GetExecution(ctx context.Context, id string) (json.RawMessa
 
 func (c *restClient) Status(ctx context.Context, id string) (json.RawMessage, error) {
 	var out json.RawMessage
-	if err := c.t.DoJSON(ctx, http.MethodGet, fmt.Sprintf(pathStatusFmt, url.PathEscape(id)), nil, &out); err != nil {
+	if err := c.doJSON(ctx, http.MethodGet, fmt.Sprintf(pathStatusFmt, url.PathEscape(id)), nil, &out); err != nil {
 		return nil, err
 	}
 	return out, nil
@@ -251,7 +305,7 @@ func (c *restClient) Status(ctx context.Context, id string) (json.RawMessage, er
 
 func (c *restClient) Respond(ctx context.Context, id string, resp HumanResponse) error {
 	body := respondRequest{Approved: resp.Approved, Reason: resp.Reason, Message: resp.Message}
-	return c.t.DoJSON(ctx, http.MethodPost, fmt.Sprintf(pathRespondFmt, url.PathEscape(id)), body, nil)
+	return c.doJSON(ctx, http.MethodPost, fmt.Sprintf(pathRespondFmt, url.PathEscape(id)), body, nil)
 }
 
 func (c *restClient) Prune(ctx context.Context, req PruneRequest) (PruneResult, error) {
@@ -261,7 +315,7 @@ func (c *restClient) Prune(ctx context.Context, req PruneRequest) (PruneResult, 
 		q.Set(queryArchiveTasks, valueTrue)
 	}
 	var pr pruneResponse
-	if err := c.t.DoJSON(ctx, http.MethodPost, pathPrune+"?"+q.Encode(), nil, &pr); err != nil {
+	if err := c.doJSON(ctx, http.MethodPost, pathPrune+"?"+q.Encode(), nil, &pr); err != nil {
 		return PruneResult{}, err
 	}
 	return PruneResult{Removed: pr.Deleted}, nil

--- a/internal/agent/client_test.go
+++ b/internal/agent/client_test.go
@@ -16,6 +16,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -193,6 +194,53 @@ func TestGetReturnsRawPassthrough(t *testing.T) {
 	}
 	if string(out) != payload {
 		t.Errorf("got %s, want %s", out, payload)
+	}
+}
+
+func TestListReportsUnsupportedAgentsAPI(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+
+	_, err := c.List(context.Background())
+	if err == nil || err.Error() != unsupportedAPIMessage {
+		t.Fatalf("error = %v, want %q", err, unsupportedAPIMessage)
+	}
+}
+
+func TestGetReportsUnsupportedAgentsAPIWhenProbeIsAlsoMissing(t *testing.T) {
+	var paths []string
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		http.NotFound(w, r)
+	})
+
+	_, err := c.Get(context.Background(), "greeter", nil)
+	if err == nil || err.Error() != unsupportedAPIMessage {
+		t.Fatalf("error = %v, want %q", err, unsupportedAPIMessage)
+	}
+	if len(paths) != 2 || paths[0] != pathAgents+"/greeter" || paths[1] != pathList {
+		t.Fatalf("request paths = %v, want resource request followed by capability probe", paths)
+	}
+}
+
+func TestGetPreservesResourceNotFoundWhenAgentsAPIExists(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == pathList {
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"agent not found"}`))
+	})
+
+	_, err := c.Get(context.Background(), "missing", nil)
+	var apiErr *transport.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error = %T, want *transport.APIError", err)
+	}
+	if apiErr.Message != "agent not found" {
+		t.Fatalf("message = %q, want agent not found", apiErr.Message)
 	}
 }
 

--- a/internal/agent/client_test.go
+++ b/internal/agent/client_test.go
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/conductor-oss/conductor-cli/internal/transport"
+)
+
+func newTestClient(t *testing.T, h http.HandlerFunc) Client {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	return NewClient(transport.Config{BaseURL: srv.URL})
+}
+
+func TestListAgents(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != pathList {
+			t.Errorf("path = %q, want %q", r.URL.Path, pathList)
+		}
+		_, _ = w.Write([]byte(`[{"name":"greeter","version":2,"type":"native"}]`))
+	})
+	out, err := c.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(out) != 1 || out[0].Name != "greeter" || out[0].Version != 2 {
+		t.Errorf("got %+v", out)
+	}
+}
+
+func TestRunSendsAgentConfigEnvelope(t *testing.T) {
+	var body startRequest
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != pathStart {
+			t.Errorf("got %s %s, want POST %s", r.Method, r.URL.Path, pathStart)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		_, _ = w.Write([]byte(`{"executionId":"e1","agentName":"greeter"}`))
+	})
+	exec, err := c.Run(context.Background(), RunRequest{
+		Definition: json.RawMessage(`{"name":"greeter"}`),
+		Prompt:     "hi",
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if exec.ID != "e1" || exec.AgentName != "greeter" {
+		t.Errorf("exec = %+v", exec)
+	}
+	if body.Prompt != "hi" || string(body.AgentConfig) != `{"name":"greeter"}` {
+		t.Errorf("request body = %+v", body)
+	}
+}
+
+func TestRunSendsFrameworkEnvelope(t *testing.T) {
+	var raw map[string]json.RawMessage
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&raw)
+		_, _ = w.Write([]byte(`{"executionId":"e2","agentName":"x"}`))
+	})
+	_, err := c.Run(context.Background(), RunRequest{
+		Framework:  "openai",
+		Definition: json.RawMessage(`{"name":"x"}`),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if _, ok := raw["framework"]; !ok {
+		t.Errorf("expected framework envelope, got keys %v", keysOf(raw))
+	}
+	if _, ok := raw["agentConfig"]; ok {
+		t.Error("framework envelope must not carry agentConfig")
+	}
+}
+
+// staticToken is a TokenProvider that always yields the same JWT.
+type staticToken string
+
+func (s staticToken) Token(context.Context) (string, error) { return string(s), nil }
+
+func TestDeploySendsFrameworkEnvelopeAndDecodes(t *testing.T) {
+	var req deployRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != pathDeploy {
+			t.Errorf("got %s %s, want POST %s", r.Method, r.URL.Path, pathDeploy)
+		}
+		if got := r.Header.Get("X-Authorization"); got != "jwt-123" {
+			t.Errorf("X-Authorization = %q, want %q", got, "jwt-123")
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		_, _ = w.Write([]byte(`{"agentName":"my-skill","requiredWorkers":["my-skill__run"]}`))
+	}))
+	t.Cleanup(srv.Close)
+	c := NewClient(transport.Config{BaseURL: srv.URL, Tokens: staticToken("jwt-123")})
+
+	res, err := c.Deploy(context.Background(), "skill", json.RawMessage(`{"skillMd":"hi"}`))
+	if err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	if req.Framework != "skill" || string(req.RawConfig) != `{"skillMd":"hi"}` {
+		t.Errorf("request = %+v", req)
+	}
+	if res.AgentName != "my-skill" || len(res.RequiredWorkers) != 1 || res.RequiredWorkers[0] != "my-skill__run" {
+		t.Errorf("result = %+v", res)
+	}
+}
+
+func TestDeployNormalizesErrorResponse(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"message":"bad skill"}`))
+	})
+	_, err := c.Deploy(context.Background(), "skill", json.RawMessage(`{}`))
+	apiErr, ok := err.(*transport.APIError)
+	if !ok {
+		t.Fatalf("error = %T, want *transport.APIError", err)
+	}
+	if apiErr.Status != http.StatusBadRequest || apiErr.Message != "bad skill" {
+		t.Errorf("apiErr = %+v", apiErr)
+	}
+}
+
+func TestSearchExecutionsSetsQuery(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get(queryAgentName) != "greeter" || q.Get(queryStatus) != "FAILED" {
+			t.Errorf("query = %v", q)
+		}
+		if q.Get(querySort) != sortExecutions {
+			t.Errorf("sort = %q, want %q", q.Get(querySort), sortExecutions)
+		}
+		_, _ = w.Write([]byte(`{"totalHits":1,"results":[{"executionId":"e1","status":"FAILED"}]}`))
+	})
+	page, err := c.SearchExecutions(context.Background(), ExecutionFilter{
+		AgentName: "greeter", Status: "FAILED", Size: 10,
+	})
+	if err != nil {
+		t.Fatalf("SearchExecutions: %v", err)
+	}
+	if page.TotalHits != 1 || len(page.Results) != 1 || page.Results[0].ExecutionID != "e1" {
+		t.Errorf("page = %+v", page)
+	}
+}
+
+func TestPruneReturnsDeletedCount(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != pathPrune {
+			t.Errorf("path = %q, want %q", r.URL.Path, pathPrune)
+		}
+		if got := r.URL.Query().Get(queryOlderThanDays); got != "7" {
+			t.Errorf("olderThanDays = %q, want 7", got)
+		}
+		_, _ = w.Write([]byte(`{"deleted":5}`))
+	})
+	res, err := c.Prune(context.Background(), PruneRequest{OlderThanDays: 7})
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if res.Removed != 5 {
+		t.Errorf("removed = %d, want 5", res.Removed)
+	}
+}
+
+func TestGetReturnsRawPassthrough(t *testing.T) {
+	const payload = `{"name":"greeter","_framework":"openai"}`
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != pathAgents+"/greeter" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(payload))
+	})
+	out, err := c.Get(context.Background(), "greeter", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(out) != payload {
+		t.Errorf("got %s, want %s", out, payload)
+	}
+}
+
+func TestStreamReadsSSE(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get(headerAccept); got != mimeEventStream {
+			t.Errorf("Accept = %q, want %q", got, mimeEventStream)
+		}
+		w.Header().Set("Content-Type", mimeEventStream)
+		_, _ = w.Write([]byte("event: message\ndata: {\"content\":\"hi\"}\n\nevent: done\ndata: {}\n\n"))
+	})
+
+	events, errc := c.Stream(context.Background(), "exec-1", "")
+	var got []SSEEvent
+	for e := range events {
+		got = append(got, e)
+	}
+	if err := <-errc; err != nil {
+		t.Fatalf("stream error: %v", err)
+	}
+	if len(got) != 2 || got[0].Type != EventMessage || got[1].Type != EventDone {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func keysOf(m map[string]json.RawMessage) []string {
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	return ks
+}

--- a/internal/agent/events.go
+++ b/internal/agent/events.go
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package agent
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"strings"
+)
+
+// EventType enumerates the streamed agent event kinds. Defining them as named
+// constants keeps event handling free of magic strings — the SSE parser tags each
+// event and the renderers switch on these.
+type EventType string
+
+const (
+	EventThinking      EventType = "thinking"
+	EventToolCall      EventType = "tool_call"
+	EventToolResult    EventType = "tool_result"
+	EventHandoff       EventType = "handoff"
+	EventMessage       EventType = "message"
+	EventWaiting       EventType = "waiting"
+	EventGuardrailPass EventType = "guardrail_pass"
+	EventGuardrailFail EventType = "guardrail_fail"
+	EventError         EventType = "error"
+	EventDone          EventType = "done"
+)
+
+// SSE framing tokens and limits.
+const (
+	sseMaxLineBytes = 1024 * 1024 // generous line buffer for large data frames
+	fieldID         = "id:"
+	fieldEvent      = "event:"
+	fieldData       = "data:"
+	fieldComment    = ":"
+)
+
+// SSEEvent is one decoded Server-Sent Event. Data stays raw so the transport layer
+// never needs to know each event's payload schema — the presentation layer decodes it.
+type SSEEvent struct {
+	ID   string
+	Type EventType
+	Data json.RawMessage
+}
+
+// ResolvedType returns the event's type, preferring the SSE event field and falling
+// back to a "type" field inside the data payload (some events carry the kind there).
+func (e SSEEvent) ResolvedType() EventType {
+	if e.Type != "" {
+		return e.Type
+	}
+	var probe struct {
+		Type string `json:"type"`
+	}
+	if json.Unmarshal(e.Data, &probe) == nil {
+		return EventType(probe.Type)
+	}
+	return ""
+}
+
+// parseSSE reads a text/event-stream body and emits one SSEEvent per record onto
+// out, following WHATWG SSE framing: a blank line ends a record, ":" lines are
+// comments (heartbeats), and multi-line data is joined with newlines. It returns the
+// scanner error (or nil) when the stream ends; the caller owns closing out.
+func parseSSE(r io.Reader, out chan<- SSEEvent) error {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, sseMaxLineBytes), sseMaxLineBytes)
+
+	var id, event string
+	var dataLines []string
+
+	flush := func() {
+		if len(dataLines) == 0 && event == "" {
+			return
+		}
+		out <- SSEEvent{
+			ID:   id,
+			Type: EventType(event),
+			Data: json.RawMessage(strings.Join(dataLines, "\n")),
+		}
+		id, event, dataLines = "", "", dataLines[:0]
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case line == "":
+			flush()
+		case strings.HasPrefix(line, fieldComment):
+			// comment / heartbeat — ignore
+		case strings.HasPrefix(line, fieldID):
+			id = sseFieldValue(line, fieldID)
+		case strings.HasPrefix(line, fieldEvent):
+			event = sseFieldValue(line, fieldEvent)
+		case strings.HasPrefix(line, fieldData):
+			dataLines = append(dataLines, sseFieldValue(line, fieldData))
+		}
+	}
+	flush()
+	return scanner.Err()
+}
+
+// sseFieldValue strips the field prefix and, per the WHATWG SSE spec, exactly one
+// leading U+0020 space (not all whitespace).
+func sseFieldValue(line, prefix string) string {
+	return strings.TrimPrefix(strings.TrimPrefix(line, prefix), " ")
+}

--- a/internal/agent/events_test.go
+++ b/internal/agent/events_test.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func collectSSE(t *testing.T, body string) []SSEEvent {
+	t.Helper()
+	out := make(chan SSEEvent, 16)
+	go func() {
+		_ = parseSSE(strings.NewReader(body), out)
+		close(out)
+	}()
+	var got []SSEEvent
+	for e := range out {
+		got = append(got, e)
+	}
+	return got
+}
+
+func TestParseSSEFramingAndComments(t *testing.T) {
+	// A heartbeat comment, a typed event, then a multi-line data record.
+	body := ": keep-alive\n" +
+		"event: message\n" +
+		"data: {\"content\":\"hi\"}\n" +
+		"\n" +
+		"event: done\n" +
+		"data: line1\n" +
+		"data: line2\n" +
+		"\n"
+
+	got := collectSSE(t, body)
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2: %+v", len(got), got)
+	}
+	if got[0].Type != EventMessage || string(got[0].Data) != `{"content":"hi"}` {
+		t.Errorf("event 0 = %+v", got[0])
+	}
+	if got[1].Type != EventDone || string(got[1].Data) != "line1\nline2" {
+		t.Errorf("event 1 = %+v", got[1])
+	}
+}
+
+func TestResolvedTypeFallsBackToDataType(t *testing.T) {
+	e := SSEEvent{Data: []byte(`{"type":"thinking"}`)}
+	if e.ResolvedType() != EventThinking {
+		t.Errorf("ResolvedType = %q, want thinking", e.ResolvedType())
+	}
+}

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// frameworkSkill is the framework marker inferred for skill-backed agent definitions.
+const frameworkSkill = "skill"
+
+// EventSink receives streamed events. It decouples streaming from rendering: the cmd
+// layer supplies a terminal sink, the TUI a sink that posts UI messages, tests a
+// recorder. Returning an error stops the stream.
+type EventSink interface {
+	OnEvent(SSEEvent) error
+}
+
+// Service is the agent use-case layer. It depends only on Client and is free of
+// presentation and transport concerns.
+type Service interface {
+	Run(ctx context.Context, req RunRequest) (Execution, error)
+	Deploy(ctx context.Context, framework string, rawConfig json.RawMessage) (DeployResult, error)
+	StreamExecution(ctx context.Context, executionID, lastEventID string, sink EventSink) error
+	List(ctx context.Context) ([]AgentSummary, error)
+	Get(ctx context.Context, name string, version *int) (json.RawMessage, error)
+	Delete(ctx context.Context, name string, version *int) error
+	Compile(ctx context.Context, def json.RawMessage) (json.RawMessage, error)
+	SearchExecutions(ctx context.Context, filter ExecutionFilter) (ExecutionPage, error)
+	GetExecution(ctx context.Context, id string) (json.RawMessage, error)
+	Status(ctx context.Context, id string) (json.RawMessage, error)
+	Respond(ctx context.Context, id string, resp HumanResponse) error
+	Prune(ctx context.Context, req PruneRequest) (PruneResult, error)
+}
+
+// NewService returns a Service backed by the given Client.
+func NewService(c Client) Service {
+	return &service{client: c}
+}
+
+type service struct {
+	client Client
+}
+
+// Run starts an agent execution. In name-mode (Name set, no inline Definition) it
+// first fetches the registered definition and, when that definition declares a
+// framework, starts it through the framework envelope — mirroring the AgentSpan CLI.
+func (s *service) Run(ctx context.Context, req RunRequest) (Execution, error) {
+	if req.Name == "" && len(req.Definition) == 0 {
+		return Execution{}, fmt.Errorf("run requires either an inline definition or a registered agent name")
+	}
+	if req.Name != "" && len(req.Definition) == 0 {
+		def, err := s.client.Get(ctx, req.Name, nil)
+		if err != nil {
+			return Execution{}, err
+		}
+		req.Definition = def
+		req.Framework = detectFramework(def)
+	}
+	return s.client.Run(ctx, req)
+}
+
+// Deploy publishes a framework agent definition without starting it.
+func (s *service) Deploy(ctx context.Context, framework string, rawConfig json.RawMessage) (DeployResult, error) {
+	return s.client.Deploy(ctx, framework, rawConfig)
+}
+
+// StreamExecution streams an execution's events into the sink until the stream ends.
+// A context cancellation (e.g. Ctrl-C) is treated as a clean stop, not an error.
+func (s *service) StreamExecution(ctx context.Context, executionID, lastEventID string, sink EventSink) error {
+	events, errc := s.client.Stream(ctx, executionID, lastEventID)
+	for evt := range events {
+		if err := sink.OnEvent(evt); err != nil {
+			return err
+		}
+	}
+	if err := <-errc; err != nil && !errors.Is(err, context.Canceled) {
+		return err
+	}
+	return nil
+}
+
+func (s *service) List(ctx context.Context) ([]AgentSummary, error) {
+	return s.client.List(ctx)
+}
+
+func (s *service) Get(ctx context.Context, name string, version *int) (json.RawMessage, error) {
+	return s.client.Get(ctx, name, version)
+}
+
+func (s *service) Delete(ctx context.Context, name string, version *int) error {
+	return s.client.Delete(ctx, name, version)
+}
+
+func (s *service) Compile(ctx context.Context, def json.RawMessage) (json.RawMessage, error) {
+	return s.client.Compile(ctx, def)
+}
+
+func (s *service) SearchExecutions(ctx context.Context, filter ExecutionFilter) (ExecutionPage, error) {
+	return s.client.SearchExecutions(ctx, filter)
+}
+
+func (s *service) GetExecution(ctx context.Context, id string) (json.RawMessage, error) {
+	return s.client.GetExecution(ctx, id)
+}
+
+func (s *service) Status(ctx context.Context, id string) (json.RawMessage, error) {
+	return s.client.Status(ctx, id)
+}
+
+func (s *service) Respond(ctx context.Context, id string, resp HumanResponse) error {
+	return s.client.Respond(ctx, id, resp)
+}
+
+func (s *service) Prune(ctx context.Context, req PruneRequest) (PruneResult, error) {
+	return s.client.Prune(ctx, req)
+}
+
+// detectFramework returns the stored framework marker on an agent definition, or ""
+// for a native agent. Framework agents (skill/openai/…) start via a different envelope.
+func detectFramework(def json.RawMessage) string {
+	var probe struct {
+		Framework string `json:"_framework"`
+		SkillMd   string `json:"skillMd"`
+	}
+	if json.Unmarshal(def, &probe) != nil {
+		return ""
+	}
+	if probe.Framework != "" {
+		return probe.Framework
+	}
+	if probe.SkillMd != "" {
+		return frameworkSkill
+	}
+	return ""
+}

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -33,6 +33,7 @@ type EventSink interface {
 // Service is the agent use-case layer. It depends only on Client and is free of
 // presentation and transport concerns.
 type Service interface {
+	CheckSupported(ctx context.Context) error
 	Run(ctx context.Context, req RunRequest) (Execution, error)
 	Deploy(ctx context.Context, framework string, rawConfig json.RawMessage) (DeployResult, error)
 	StreamExecution(ctx context.Context, executionID, lastEventID string, sink EventSink) error
@@ -54,6 +55,10 @@ func NewService(c Client) Service {
 
 type service struct {
 	client Client
+}
+
+func (s *service) CheckSupported(ctx context.Context) error {
+	return s.client.CheckSupported(ctx)
 }
 
 // Run starts an agent execution. In name-mode (Name set, no inline Definition) it

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+// fakeClient records calls and returns canned values; it implements Client so the
+// service can be tested in isolation.
+type fakeClient struct {
+	getDef        json.RawMessage
+	getCalled     bool
+	lastRun       RunRequest
+	lastDeployFwk string
+	lastDeployCfg json.RawMessage
+	deployResult  DeployResult
+	streamEvents  []SSEEvent
+	streamErr     error
+}
+
+func (f *fakeClient) Run(ctx context.Context, req RunRequest) (Execution, error) {
+	f.lastRun = req
+	return Execution{ID: "exec-1", AgentName: req.Name}, nil
+}
+
+func (f *fakeClient) Deploy(ctx context.Context, framework string, rawConfig json.RawMessage) (DeployResult, error) {
+	f.lastDeployFwk = framework
+	f.lastDeployCfg = rawConfig
+	return f.deployResult, nil
+}
+
+func (f *fakeClient) Stream(ctx context.Context, id, lastEventID string) (<-chan SSEEvent, <-chan error) {
+	events := make(chan SSEEvent, len(f.streamEvents))
+	errc := make(chan error, 1)
+	for _, e := range f.streamEvents {
+		events <- e
+	}
+	close(events)
+	errc <- f.streamErr
+	close(errc)
+	return events, errc
+}
+
+func (f *fakeClient) Get(ctx context.Context, name string, version *int) (json.RawMessage, error) {
+	f.getCalled = true
+	return f.getDef, nil
+}
+
+func (f *fakeClient) List(ctx context.Context) ([]AgentSummary, error)      { return nil, nil }
+func (f *fakeClient) Delete(ctx context.Context, name string, v *int) error { return nil }
+func (f *fakeClient) Compile(ctx context.Context, d json.RawMessage) (json.RawMessage, error) {
+	return nil, nil
+}
+func (f *fakeClient) SearchExecutions(ctx context.Context, _ ExecutionFilter) (ExecutionPage, error) {
+	return ExecutionPage{}, nil
+}
+func (f *fakeClient) GetExecution(ctx context.Context, id string) (json.RawMessage, error) {
+	return nil, nil
+}
+func (f *fakeClient) Status(ctx context.Context, id string) (json.RawMessage, error) {
+	return nil, nil
+}
+func (f *fakeClient) Respond(ctx context.Context, id string, r HumanResponse) error { return nil }
+func (f *fakeClient) Prune(ctx context.Context, req PruneRequest) (PruneResult, error) {
+	return PruneResult{}, nil
+}
+
+func TestRunNameModeFetchesDefinitionAndDetectsFramework(t *testing.T) {
+	fc := &fakeClient{getDef: json.RawMessage(`{"name":"x","_framework":"openai"}`)}
+	svc := NewService(fc)
+
+	if _, err := svc.Run(context.Background(), RunRequest{Name: "x", Prompt: "hi"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !fc.getCalled {
+		t.Error("expected name-mode Run to fetch the definition")
+	}
+	if fc.lastRun.Framework != "openai" {
+		t.Errorf("framework = %q, want openai", fc.lastRun.Framework)
+	}
+	if string(fc.lastRun.Definition) != string(fc.getDef) {
+		t.Errorf("definition = %s, want %s", fc.lastRun.Definition, fc.getDef)
+	}
+}
+
+func TestRunRequiresNameOrDefinition(t *testing.T) {
+	svc := NewService(&fakeClient{})
+	if _, err := svc.Run(context.Background(), RunRequest{Prompt: "hi"}); err == nil {
+		t.Fatal("expected an error when neither name nor definition is provided")
+	}
+}
+
+func TestDeployPassesThroughToClient(t *testing.T) {
+	fc := &fakeClient{deployResult: DeployResult{AgentName: "my-skill", RequiredWorkers: []string{"my-skill__run"}}}
+	res, err := NewService(fc).Deploy(context.Background(), "skill", json.RawMessage(`{"skillMd":"hi"}`))
+	if err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	if fc.lastDeployFwk != "skill" || string(fc.lastDeployCfg) != `{"skillMd":"hi"}` {
+		t.Errorf("client saw framework=%q cfg=%s", fc.lastDeployFwk, fc.lastDeployCfg)
+	}
+	if res.AgentName != "my-skill" || len(res.RequiredWorkers) != 1 {
+		t.Errorf("result = %+v", res)
+	}
+}
+
+type recordingSink struct {
+	events []SSEEvent
+}
+
+func (r *recordingSink) OnEvent(e SSEEvent) error {
+	r.events = append(r.events, e)
+	return nil
+}
+
+func TestStreamExecutionForwardsEventsAndIgnoresCancel(t *testing.T) {
+	fc := &fakeClient{
+		streamEvents: []SSEEvent{{Type: EventMessage}, {Type: EventDone}},
+		streamErr:    context.Canceled, // simulate Ctrl-C; must be treated as a clean stop
+	}
+	sink := &recordingSink{}
+	if err := NewService(fc).StreamExecution(context.Background(), "exec-1", "", sink); err != nil {
+		t.Fatalf("StreamExecution: %v", err)
+	}
+	if len(sink.events) != 2 {
+		t.Fatalf("forwarded %d events, want 2", len(sink.events))
+	}
+}
+
+func TestStreamExecutionReturnsRealError(t *testing.T) {
+	fc := &fakeClient{streamErr: errors.New("boom")}
+	if err := NewService(fc).StreamExecution(context.Background(), "exec-1", "", &recordingSink{}); err == nil {
+		t.Fatal("expected the terminal stream error to surface")
+	}
+}

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -33,6 +33,8 @@ type fakeClient struct {
 	streamErr     error
 }
 
+func (f *fakeClient) CheckSupported(ctx context.Context) error { return nil }
+
 func (f *fakeClient) Run(ctx context.Context, req RunRequest) (Execution, error) {
 	f.lastRun = req
 	return Execution{ID: "exec-1", AgentName: req.Name}, nil

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+// Package agent is the CLI-owned client and service for the Conductor agent
+// endpoints (/api/agent/*), which are served by the merged server but are not part
+// of the conductor-go SDK. The package is layered: domain types here, the transport
+// boundary in client.go, and use-case orchestration in service.go. No file paths or
+// transport types cross into this package — callers pass parsed bytes and structs.
+package agent
+
+import "encoding/json"
+
+// RunRequest starts an agent execution. Definition is an already-parsed inline agent
+// config (the cmd layer read it from disk and marshaled it to JSON); it is opaque
+// here. When Framework is non-empty the execution starts through the framework
+// envelope (skill/openai/… agents) instead of the native agent-config envelope.
+type RunRequest struct {
+	Name       string
+	Prompt     string
+	Definition json.RawMessage
+	Framework  string
+	SessionID  string
+}
+
+// Execution identifies a started or running agent execution.
+type Execution struct {
+	ID        string
+	AgentName string
+	Status    string
+}
+
+// DeployResult reports the outcome of publishing (deploying) an agent definition
+// without starting an execution. RequiredWorkers lists the tool task types the
+// caller must serve for the deployed agent to run (empty for a native agent).
+type DeployResult struct {
+	AgentName       string
+	RequiredWorkers []string
+}
+
+// AgentSummary is the list view of a registered agent.
+type AgentSummary struct {
+	Name        string   `json:"name"`
+	Version     int      `json:"version"`
+	Type        string   `json:"type"`
+	Description string   `json:"description"`
+	Tags        []string `json:"tags"`
+}
+
+// ExecutionFilter narrows an execution search. Start/Size paginate.
+type ExecutionFilter struct {
+	AgentName string
+	Status    string
+	FreeText  string
+	Start     int
+	Size      int
+}
+
+// ExecutionPage is one page of execution-search results.
+type ExecutionPage struct {
+	TotalHits int64              `json:"totalHits"`
+	Results   []ExecutionSummary `json:"results"`
+}
+
+// ExecutionSummary is the list view of a single execution.
+type ExecutionSummary struct {
+	ExecutionID   string `json:"executionId"`
+	AgentName     string `json:"agentName"`
+	Version       int    `json:"version"`
+	Status        string `json:"status"`
+	StartTime     string `json:"startTime"`
+	EndTime       string `json:"endTime"`
+	ExecutionTime int64  `json:"executionTime"`
+}
+
+// PruneRequest selects terminal executions to delete (or archive) by age.
+type PruneRequest struct {
+	OlderThanDays int
+	Archive       bool
+}
+
+// PruneResult reports how many execution records were removed.
+type PruneResult struct {
+	Removed int
+}
+
+// HumanResponse answers a human-in-the-loop task.
+type HumanResponse struct {
+	Approved bool
+	Reason   string
+	Message  string
+}

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+// Package deploy bridges Conductor's connection config into the environment of the
+// language-specific (Python/TypeScript) deploy subprocess, and abstracts subprocess
+// execution behind an interface. The env-var names are named constants — never inline
+// literals — and the server URL/token come from config, not hardcoded values.
+package deploy
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Subprocess environment variables the AgentSpan SDKs read.
+const (
+	EnvServerURL = "AGENTSPAN_SERVER_URL"
+	EnvAuthToken = "AGENTSPAN_AUTH_TOKEN"
+	EnvAutoStart = "AGENTSPAN_AUTO_START_SERVER"
+
+	envPrefix    = "AGENTSPAN_"
+	autoStartOff = "false"
+
+	subprocessTimeout = 120 * time.Second
+)
+
+// TokenSource yields the JWT to forward to the subprocess. It matches
+// transport.TokenProvider structurally, so the shared transport's provider can be
+// passed directly.
+type TokenSource interface {
+	Token(ctx context.Context) (string, error)
+}
+
+// EnvBuilder builds the subprocess environment from Conductor's connection config:
+// it strips inherited AGENTSPAN_* vars, sets the server URL, disables the SDK's
+// embedded-server auto-start, and forwards the resolved JWT as AGENTSPAN_AUTH_TOKEN.
+//
+// Cross-component note (design §7): forwarding the JWT — rather than a legacy API
+// key — requires the Python/TypeScript SDKs to authenticate with AGENTSPAN_AUTH_TOKEN.
+// This is the single cross-component dependency of the port.
+type EnvBuilder struct {
+	BaseURL string
+	Tokens  TokenSource // nil => anonymous
+	BaseEnv []string    // typically os.Environ(); injected for testability
+}
+
+// Build returns the child-process environment.
+func (b EnvBuilder) Build(ctx context.Context) ([]string, error) {
+	out := make([]string, 0, len(b.BaseEnv)+3)
+	for _, e := range b.BaseEnv {
+		if !strings.HasPrefix(e, envPrefix) {
+			out = append(out, e)
+		}
+	}
+	out = append(out, EnvServerURL+"="+b.BaseURL, EnvAutoStart+"="+autoStartOff)
+	if b.Tokens != nil {
+		tok, err := b.Tokens.Token(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("resolve auth token: %w", err)
+		}
+		if tok != "" {
+			out = append(out, EnvAuthToken+"="+tok)
+		}
+	}
+	return out, nil
+}
+
+// Runner executes a language subprocess and captures stdout, forwarding stderr to the
+// user. It is an interface so the deploy command can be tested without spawning processes.
+type Runner interface {
+	Run(ctx context.Context, env []string, name string, args ...string) ([]byte, error)
+}
+
+// NewRunner returns the default subprocess Runner.
+func NewRunner() Runner { return execRunner{} }
+
+type execRunner struct{}
+
+func (execRunner) Run(ctx context.Context, env []string, name string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, subprocessTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = env
+	cmd.Stderr = os.Stderr
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+
+	err := cmd.Run()
+	if err != nil && stdout.Len() > 0 {
+		// Subprocess may have written results before failing — return partial output.
+		return stdout.Bytes(), err
+	}
+	if err != nil {
+		return nil, fmt.Errorf("run %s: %w", name, err)
+	}
+	return stdout.Bytes(), nil
+}

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package deploy
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+type staticToken string
+
+func (s staticToken) Token(context.Context) (string, error) { return string(s), nil }
+
+func envValue(env []string, key string) (string, bool) {
+	for _, e := range env {
+		if strings.HasPrefix(e, key+"=") {
+			return strings.TrimPrefix(e, key+"="), true
+		}
+	}
+	return "", false
+}
+
+func TestEnvBuilderStripsStaleAndInjectsConnection(t *testing.T) {
+	b := EnvBuilder{
+		BaseURL: "http://localhost:8080/api",
+		Tokens:  staticToken("jwt-x"),
+		BaseEnv: []string{"PATH=/usr/bin", "AGENTSPAN_SERVER_URL=stale", "AGENTSPAN_API_KEY=old"},
+	}
+	env, err := b.Build(context.Background())
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	if _, ok := envValue(env, "PATH"); !ok {
+		t.Error("inherited PATH should be preserved")
+	}
+	if v, _ := envValue(env, EnvServerURL); v != "http://localhost:8080/api" {
+		t.Errorf("%s = %q", EnvServerURL, v)
+	}
+	if v, _ := envValue(env, EnvAutoStart); v != autoStartOff {
+		t.Errorf("%s = %q, want %q", EnvAutoStart, v, autoStartOff)
+	}
+	if v, _ := envValue(env, EnvAuthToken); v != "jwt-x" {
+		t.Errorf("%s = %q, want jwt-x", EnvAuthToken, v)
+	}
+	// The stale AGENTSPAN_API_KEY must not survive.
+	if _, ok := envValue(env, "AGENTSPAN_API_KEY"); ok {
+		t.Error("stale AGENTSPAN_API_KEY should have been stripped")
+	}
+}
+
+func TestEnvBuilderAnonymousOmitsToken(t *testing.T) {
+	b := EnvBuilder{BaseURL: "http://localhost:8080/api", BaseEnv: []string{"PATH=/usr/bin"}}
+	env, err := b.Build(context.Background())
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if _, ok := envValue(env, EnvAuthToken); ok {
+		t.Error("anonymous build must not set an auth token")
+	}
+}

--- a/internal/settings.go
+++ b/internal/settings.go
@@ -16,11 +16,20 @@ package internal
 
 import (
 	"github.com/conductor-sdk/conductor-go/sdk/client"
+
+	"github.com/conductor-oss/conductor-cli/internal/agent"
+	"github.com/conductor-oss/conductor-cli/internal/skill"
+	"github.com/conductor-oss/conductor-cli/internal/transport"
 )
 
 var (
 	workflowClient *client.WorkflowResourceApiService = nil
 	apiClient      *client.APIClient
+
+	// agentTransport is the shared HTTP transport for the agent and skill clients,
+	// configured once at startup (cmd/root.go) from the same server URL and auth as
+	// apiClient. The agent/skill endpoints are not part of the conductor-go SDK.
+	agentTransport transport.Config
 )
 
 func GetWorkflowClient() *client.WorkflowResourceApiService {
@@ -58,4 +67,25 @@ func GetGatewayClient() client.ApiGatewayClient {
 
 func SetAPIClient(client *client.APIClient) {
 	apiClient = client
+}
+
+// SetTransport stores the shared transport used by the agent and skill clients.
+// Called once at startup after the server URL and authentication are resolved.
+func SetTransport(cfg transport.Config) {
+	agentTransport = cfg
+}
+
+// Transport returns the shared agent/skill transport configured at startup.
+func Transport() transport.Config {
+	return agentTransport
+}
+
+// GetAgentService returns the agent use-case service over the shared transport.
+func GetAgentService() agent.Service {
+	return agent.NewService(agent.NewClient(agentTransport))
+}
+
+// GetSkillService returns the skill use-case service over the shared transport.
+func GetSkillService() skill.Service {
+	return skill.NewService(skill.NewClient(agentTransport))
 }

--- a/internal/skill/client.go
+++ b/internal/skill/client.go
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package skill
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+
+	"github.com/conductor-oss/conductor-cli/internal/transport"
+)
+
+// Endpoint paths and fixed tokens — named constants, never inline literals.
+// pathSkills is relative to the transport BaseURL, which already carries the
+// "/api" prefix (see cmd/root.go); do not re-add it here.
+const (
+	pathSkills       = "/skills"
+	registerSegment  = "/register"
+	versionSegment   = "/versions/"
+	packageSegment   = "/package"
+	queryAllVersions = "allVersions"
+	valueTrue        = "true"
+	versionLatest    = "latest"
+
+	fieldManifest    = "manifest"
+	fieldPackage     = "package"
+	packageFileName  = "skill.zip"
+	headerContentTyp = "Content-Type"
+)
+
+// Client is the transport boundary for skill endpoints. It returns domain types or
+// raw package bytes — never *http.Response or transport types.
+type Client interface {
+	List(ctx context.Context, allVersions bool) ([]Summary, error)
+	Get(ctx context.Context, name, version string) (Detail, error)
+	DownloadPackage(ctx context.Context, name, version string) ([]byte, error)
+	Register(ctx context.Context, manifest json.RawMessage, pkg []byte) (Detail, error)
+	Delete(ctx context.Context, name, version string) error
+}
+
+// NewClient returns a Client backed by the shared transport.
+func NewClient(t transport.Config) Client {
+	return &restClient{t: t}
+}
+
+type restClient struct {
+	t transport.Config
+}
+
+func (c *restClient) List(ctx context.Context, allVersions bool) ([]Summary, error) {
+	path := pathSkills
+	if allVersions {
+		q := url.Values{}
+		q.Set(queryAllVersions, valueTrue)
+		path += "?" + q.Encode()
+	}
+	var out []Summary
+	if err := c.t.DoJSON(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *restClient) Get(ctx context.Context, name, version string) (Detail, error) {
+	path := pathSkills + "/" + url.PathEscape(name)
+	if version != "" {
+		path += versionSegment + url.PathEscape(version)
+	}
+	var out Detail
+	if err := c.t.DoJSON(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return Detail{}, err
+	}
+	return out, nil
+}
+
+func (c *restClient) DownloadPackage(ctx context.Context, name, version string) ([]byte, error) {
+	path := pathSkills + "/" + url.PathEscape(name) + versionSegment + url.PathEscape(resolveVersion(version)) + packageSegment
+	resp, err := c.t.Do(ctx, http.MethodGet, path, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	return io.ReadAll(resp.Body)
+}
+
+// Register uploads a skill manifest (JSON) and its package (zip) as multipart form
+// data. The manifest is built by the cmd layer from the local skill directory; the
+// client only frames the request — it never touches the filesystem.
+func (c *restClient) Register(ctx context.Context, manifest json.RawMessage, pkg []byte) (Detail, error) {
+	var body bytes.Buffer
+	w := multipart.NewWriter(&body)
+	mf, err := w.CreateFormField(fieldManifest)
+	if err != nil {
+		return Detail{}, err
+	}
+	if _, err := mf.Write(manifest); err != nil {
+		return Detail{}, err
+	}
+	pf, err := w.CreateFormFile(fieldPackage, packageFileName)
+	if err != nil {
+		return Detail{}, err
+	}
+	if _, err := pf.Write(pkg); err != nil {
+		return Detail{}, err
+	}
+	if err := w.Close(); err != nil {
+		return Detail{}, fmt.Errorf("close multipart body: %w", err)
+	}
+
+	header := http.Header{}
+	header.Set(headerContentTyp, w.FormDataContentType())
+	resp, err := c.t.Do(ctx, http.MethodPost, pathSkills+registerSegment, &body, header)
+	if err != nil {
+		return Detail{}, err
+	}
+	defer resp.Body.Close()
+	var out Detail
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return Detail{}, fmt.Errorf("decode response: %w", err)
+	}
+	return out, nil
+}
+
+func (c *restClient) Delete(ctx context.Context, name, version string) error {
+	path := pathSkills + "/" + url.PathEscape(name) + versionSegment + url.PathEscape(resolveVersion(version))
+	return c.t.DoJSON(ctx, http.MethodDelete, path, nil, nil)
+}
+
+// resolveVersion defaults an empty version to "latest", matching the server's
+// version-pinned package and delete endpoints.
+func resolveVersion(version string) string {
+	if version == "" {
+		return versionLatest
+	}
+	return version
+}

--- a/internal/skill/client_test.go
+++ b/internal/skill/client_test.go
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package skill
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/conductor-oss/conductor-cli/internal/transport"
+)
+
+func newTestClient(t *testing.T, h http.HandlerFunc) Client {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	return NewClient(transport.Config{BaseURL: srv.URL})
+}
+
+func TestListSkills(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != pathSkills {
+			t.Errorf("path = %q, want %q", r.URL.Path, pathSkills)
+		}
+		if r.URL.Query().Get(queryAllVersions) != valueTrue {
+			t.Errorf("expected allVersions=true, got %q", r.URL.RawQuery)
+		}
+		_, _ = w.Write([]byte(`[{"name":"summarize","version":"abc123","fileCount":3}]`))
+	})
+	out, err := c.List(context.Background(), true)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(out) != 1 || out[0].Name != "summarize" || out[0].FileCount != 3 {
+		t.Errorf("got %+v", out)
+	}
+}
+
+func TestGetSkillWithVersionPath(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		want := pathSkills + "/summarize" + versionSegment + "v1"
+		if r.URL.Path != want {
+			t.Errorf("path = %q, want %q", r.URL.Path, want)
+		}
+		_, _ = w.Write([]byte(`{"name":"summarize","version":"v1"}`))
+	})
+	d, err := c.Get(context.Background(), "summarize", "v1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if d.Version != "v1" {
+		t.Errorf("version = %q, want v1", d.Version)
+	}
+}
+
+func TestDownloadPackageDefaultsToLatest(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		want := pathSkills + "/summarize" + versionSegment + versionLatest + packageSegment
+		if r.URL.Path != want {
+			t.Errorf("path = %q, want %q", r.URL.Path, want)
+		}
+		_, _ = w.Write([]byte("ZIPBYTES"))
+	})
+	data, err := c.DownloadPackage(context.Background(), "summarize", "")
+	if err != nil {
+		t.Fatalf("DownloadPackage: %v", err)
+	}
+	if string(data) != "ZIPBYTES" {
+		t.Errorf("got %q", data)
+	}
+}
+
+func TestRegisterSendsMultipart(t *testing.T) {
+	var gotManifest string
+	var gotPackage []byte
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != pathSkills+registerSegment {
+			t.Errorf("path = %q, want %q", r.URL.Path, pathSkills+registerSegment)
+		}
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Fatalf("parse multipart: %v", err)
+		}
+		gotManifest = r.FormValue(fieldManifest)
+		file, _, err := r.FormFile(fieldPackage)
+		if err != nil {
+			t.Fatalf("form file: %v", err)
+		}
+		defer file.Close()
+		gotPackage, _ = io.ReadAll(file)
+		_, _ = w.Write([]byte(`{"name":"summarize","version":"v1"}`))
+	})
+
+	detail, err := c.Register(context.Background(), []byte(`{"name":"summarize"}`), []byte("ZIPDATA"))
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if detail.Version != "v1" {
+		t.Errorf("version = %q, want v1", detail.Version)
+	}
+	if gotManifest != `{"name":"summarize"}` {
+		t.Errorf("manifest = %q", gotManifest)
+	}
+	if string(gotPackage) != "ZIPDATA" {
+		t.Errorf("package = %q", gotPackage)
+	}
+}
+
+func TestDeleteSkill(t *testing.T) {
+	called := false
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		if r.Method != http.MethodDelete {
+			t.Errorf("method = %q, want DELETE", r.Method)
+		}
+		want := pathSkills + "/summarize" + versionSegment + "v2"
+		if r.URL.Path != want {
+			t.Errorf("path = %q, want %q", r.URL.Path, want)
+		}
+	})
+	if err := c.Delete(context.Background(), "summarize", "v2"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if !called {
+		t.Error("delete request was not made")
+	}
+}

--- a/internal/skill/service.go
+++ b/internal/skill/service.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package skill
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// Service is the skill use-case layer. It depends only on Client and is free of
+// presentation and transport concerns.
+type Service interface {
+	List(ctx context.Context, allVersions bool) ([]Summary, error)
+	Get(ctx context.Context, name, version string) (Detail, error)
+	DownloadPackage(ctx context.Context, name, version string) ([]byte, error)
+	Register(ctx context.Context, manifest json.RawMessage, pkg []byte) (Detail, error)
+	Delete(ctx context.Context, name, version string) error
+}
+
+// NewService returns a Service backed by the given Client.
+func NewService(c Client) Service {
+	return &service{client: c}
+}
+
+type service struct {
+	client Client
+}
+
+func (s *service) List(ctx context.Context, allVersions bool) ([]Summary, error) {
+	return s.client.List(ctx, allVersions)
+}
+
+func (s *service) Get(ctx context.Context, name, version string) (Detail, error) {
+	return s.client.Get(ctx, name, version)
+}
+
+func (s *service) DownloadPackage(ctx context.Context, name, version string) ([]byte, error) {
+	return s.client.DownloadPackage(ctx, name, version)
+}
+
+func (s *service) Register(ctx context.Context, manifest json.RawMessage, pkg []byte) (Detail, error) {
+	return s.client.Register(ctx, manifest, pkg)
+}
+
+func (s *service) Delete(ctx context.Context, name, version string) error {
+	return s.client.Delete(ctx, name, version)
+}

--- a/internal/skill/types.go
+++ b/internal/skill/types.go
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+// Package skill is the CLI-owned client and service for the Conductor skill
+// endpoints (/api/skills/*). It mirrors the layering of the agent package. This
+// stage covers the server-backed management operations (list/get/pull/delete);
+// register/run/serve, which need the local skill packaging-and-execution engine,
+// build on the same client in a later step.
+package skill
+
+import "encoding/json"
+
+// Summary is the list view of a registered skill.
+type Summary struct {
+	Name          string `json:"name"`
+	Version       string `json:"version"`
+	Description   string `json:"description"`
+	Status        string `json:"status"`
+	PackageSize   int64  `json:"packageSize"`
+	FileCount     int    `json:"fileCount"`
+	ScriptCount   int    `json:"scriptCount"`
+	SubAgentCount int    `json:"subAgentCount"`
+	ResourceCount int    `json:"resourceCount"`
+}
+
+// FileEntry describes one file inside a skill package.
+type FileEntry struct {
+	Path        string `json:"path"`
+	Size        int64  `json:"size"`
+	SHA256      string `json:"sha256"`
+	ContentType string `json:"contentType"`
+}
+
+// Detail is the full server-side skill package record. RawConfig and Metadata stay
+// as raw JSON so their free-form shapes do not leak as untyped maps across a boundary.
+type Detail struct {
+	Name        string          `json:"name"`
+	Version     string          `json:"version"`
+	Description string          `json:"description"`
+	Checksum    string          `json:"checksum"`
+	Status      string          `json:"status"`
+	OwnerID     string          `json:"ownerId"`
+	CreatedAt   *int64          `json:"createdAt"`
+	UpdatedAt   *int64          `json:"updatedAt"`
+	PackageSize int64           `json:"packageSize"`
+	FileCount   int             `json:"fileCount"`
+	Files       []FileEntry     `json:"files"`
+	Metadata    json.RawMessage `json:"metadata,omitempty"`
+	RawConfig   json.RawMessage `json:"rawConfig,omitempty"`
+}

--- a/internal/skillworker/handlers.go
+++ b/internal/skillworker/handlers.go
@@ -1,0 +1,772 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package skillworker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	pathpkg "path"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Tool names (the "{tool}" half of a "{skillName}__{tool}" task type). Shared with
+// the cmd registry that maps them to these handlers.
+const (
+	ToolReadSkillFile     = "read_skill_file"
+	ToolListWorkspace     = "list_workspace_files"
+	ToolReadWorkspaceFile = "read_workspace_file"
+	ToolSearchWorkspace   = "search_workspace"
+	ToolGitStatus         = "git_status"
+	ToolGitDiff           = "git_diff"
+)
+
+// Script languages — the vocabulary produced by the payload builder's extension
+// table and consumed by executeScript, kept in one place to avoid drift.
+const (
+	LangPython = "python"
+	LangNode   = "node"
+	LangRuby   = "ruby"
+	LangGo     = "go"
+	LangBatch  = "batch"
+	LangBash   = "bash"
+)
+
+// Script execution defaults and the script-facing environment variables. The
+// AGENTSPAN_* names are a stable skill-script contract (a script reads them to find
+// its skill dir and workspace roots), so they are kept verbatim as named constants.
+const (
+	defaultScriptTimeout     = 300 * time.Second
+	defaultScriptOutputLimit = 10 << 20 // 10 MiB
+
+	envSkillDir             = "AGENTSPAN_SKILL_DIR"
+	envWorkspaceDir         = "AGENTSPAN_WORKSPACE_DIR"
+	envFilesystemRootPrefix = "AGENTSPAN_FILESYSTEM_ROOT_"
+)
+
+// Workspace tool limits and the git command timeout.
+const (
+	listDefaultLimit   = 500
+	listMaxLimit       = 5000
+	readMaxLimit       = 5 << 20 // 5 MiB
+	searchDefaultLimit = 100
+	searchMaxLimit     = 1000
+	searchLineMax      = 500
+	gitCommandTimeout  = 30 * time.Second
+)
+
+// skillSectionPrefix marks a read_skill_file request for a pre-split SKILL.md
+// section ("skill_section:{slug}") rather than a resource file.
+const skillSectionPrefix = "skill_section:"
+
+// toolFunc adapts a function to ToolHandler.
+type toolFunc func(ctx context.Context, input json.RawMessage) (json.RawMessage, error)
+
+func (f toolFunc) Handle(ctx context.Context, input json.RawMessage) (json.RawMessage, error) {
+	return f(ctx, input)
+}
+
+// ---- read_skill_file ----
+
+type readSkillFileInput struct {
+	Path string `json:"path"`
+}
+
+// NewReadSkillFileHandler serves skill resource files and pre-split SKILL.md
+// sections. Only paths in resourceFiles (and "skill_section:{slug}" for each known
+// section) are allowed; expected failures (unknown/unreadable path) are returned as
+// an "ERROR: ..." result string so the agent can see them, matching the original.
+func NewReadSkillFileHandler(skillDir string, resourceFiles []string, sections map[string]string) ToolHandler {
+	allowed := make(map[string]bool, len(resourceFiles)+len(sections))
+	for _, f := range resourceFiles {
+		allowed[f] = true
+	}
+	for name := range sections {
+		allowed[skillSectionPrefix+name] = true
+	}
+	return toolFunc(func(_ context.Context, raw json.RawMessage) (json.RawMessage, error) {
+		var in readSkillFileInput
+		if err := json.Unmarshal(raw, &in); err != nil {
+			return nil, fmt.Errorf("decode input: %w", err)
+		}
+		if in.Path == "" {
+			return nil, fmt.Errorf("missing 'path' parameter")
+		}
+		path := normalizeSkillResourcePath(in.Path)
+		if !allowed[path] {
+			return jsonString(fmt.Sprintf("ERROR: '%s' not found. Available: %v", path, sortedKeys(allowed)))
+		}
+		if strings.HasPrefix(path, skillSectionPrefix) {
+			name := strings.TrimPrefix(path, skillSectionPrefix)
+			if section, ok := sections[name]; ok {
+				return jsonString(section)
+			}
+			return jsonString(fmt.Sprintf("ERROR: section '%s' not found", name))
+		}
+		fullPath, err := safeSkillPath(skillDir, path)
+		if err != nil {
+			return jsonString(fmt.Sprintf("ERROR: %v", err))
+		}
+		data, err := os.ReadFile(fullPath)
+		if err != nil {
+			return jsonString(fmt.Sprintf("ERROR: failed to read '%s': %v", path, err))
+		}
+		return jsonString(string(data))
+	})
+}
+
+func normalizeSkillResourcePath(path string) string {
+	if strings.HasPrefix(path, skillSectionPrefix) {
+		return path
+	}
+	return pathpkg.Clean(strings.ReplaceAll(path, "\\", "/"))
+}
+
+// safeSkillPath joins relPath onto absSkillDir, rejecting escapes (skill-dir
+// boundary, symlink-resolved).
+func safeSkillPath(absSkillDir, relPath string) (string, error) {
+	cleanRel := filepath.Clean(relPath)
+	if filepath.IsAbs(cleanRel) || cleanRel == ".." || strings.HasPrefix(cleanRel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("'%s' is outside the skill directory", relPath)
+	}
+	target := filepath.Join(absSkillDir, cleanRel)
+	resolvedTarget, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		return target, nil // path may not exist yet; join is already contained
+	}
+	resolvedDir, err := filepath.EvalSymlinks(absSkillDir)
+	if err != nil {
+		resolvedDir = absSkillDir
+	}
+	if rel, err := filepath.Rel(resolvedDir, resolvedTarget); err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("'%s' is outside the skill directory", relPath)
+	}
+	return resolvedTarget, nil
+}
+
+// ---- scripts ----
+
+type scriptInput struct {
+	Command string `json:"command"`
+}
+
+// ScriptOptions bounds a script execution (zero values fall back to the defaults).
+type ScriptOptions struct {
+	Timeout     time.Duration
+	OutputLimit int
+}
+
+// NewScriptHandler runs one skill script. Script failure is returned as an error
+// whose message includes the captured output, so the failed task's reason carries
+// the diagnostic output.
+func NewScriptHandler(scriptPath, language string, ws WorkspaceConfig, opts ScriptOptions) ToolHandler {
+	return toolFunc(func(ctx context.Context, raw json.RawMessage) (json.RawMessage, error) {
+		var in scriptInput
+		if err := json.Unmarshal(raw, &in); err != nil {
+			return nil, fmt.Errorf("decode input: %w", err)
+		}
+		out, err := executeScript(ctx, scriptPath, language, in.Command, ws, opts)
+		if err != nil {
+			return nil, err
+		}
+		return jsonString(out)
+	})
+}
+
+func executeScript(ctx context.Context, scriptPath, language, command string, ws WorkspaceConfig, opts ScriptOptions) (string, error) {
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = defaultScriptTimeout
+	}
+	outputLimit := opts.OutputLimit
+	if outputLimit <= 0 {
+		outputLimit = defaultScriptOutputLimit
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := buildScriptCmd(ctx, language, scriptPath, command)
+	if skillRoot := skillRootFromScriptPath(scriptPath); skillRoot != "" {
+		cmd.Dir = skillRoot
+		cmd.Env = scriptEnv(skillRoot, ws)
+	}
+
+	output := &limitedOutputBuffer{limit: outputLimit}
+	cmd.Stdout = output
+	cmd.Stderr = output
+	err := cmd.Run()
+	out := output.String()
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return out, fmt.Errorf("script timed out after %s\n%s", timeout, out)
+		}
+		return out, fmt.Errorf("script failed: %w\n%s", err, out)
+	}
+	return out, nil
+}
+
+func buildScriptCmd(ctx context.Context, language, scriptPath, command string) *exec.Cmd {
+	args := splitCommandArgs(command)
+	switch language {
+	case LangPython:
+		py := "python3"
+		if _, err := exec.LookPath("python3"); err != nil {
+			py = "python" // Windows ships python, not python3
+		}
+		return exec.CommandContext(ctx, py, append([]string{scriptPath}, args...)...)
+	case LangNode:
+		return exec.CommandContext(ctx, "node", append([]string{scriptPath}, args...)...)
+	case LangRuby:
+		return exec.CommandContext(ctx, "ruby", append([]string{scriptPath}, args...)...)
+	case LangGo:
+		return exec.CommandContext(ctx, "go", append([]string{"run", scriptPath}, args...)...)
+	case LangBatch:
+		return exec.CommandContext(ctx, "cmd", append([]string{"/c", scriptPath}, args...)...)
+	default: // LangBash / shell
+		if runtime.GOOS != "windows" {
+			return exec.CommandContext(ctx, "bash", append([]string{scriptPath}, args...)...)
+		}
+		if _, err := exec.LookPath("bash"); err == nil {
+			return exec.CommandContext(ctx, "bash", append([]string{scriptPath}, args...)...)
+		}
+		return exec.CommandContext(ctx, "cmd", append([]string{"/c", scriptPath}, args...)...)
+	}
+}
+
+// skillRootFromScriptPath returns the skill directory for a "…/scripts/foo" path,
+// or "" when the script is not under a scripts/ directory.
+func skillRootFromScriptPath(scriptPath string) string {
+	scriptsDir := filepath.Dir(scriptPath)
+	if filepath.Base(scriptsDir) != scriptsDirName {
+		return ""
+	}
+	return filepath.Dir(scriptsDir)
+}
+
+// scriptsDirName mirrors the payload builder's scripts directory name.
+const scriptsDirName = "scripts"
+
+func scriptEnv(skillRoot string, ws WorkspaceConfig) []string {
+	env := append(os.Environ(), envSkillDir+"="+skillRoot)
+	if wsRoot, ok := ws.Root(workspaceRootName); ok {
+		env = append(env, envWorkspaceDir+"="+wsRoot.Path)
+	}
+	for _, root := range ws.Roots {
+		env = append(env, envFilesystemRootPrefix+filesystemEnvName(root.Name)+"="+root.Path)
+	}
+	return env
+}
+
+var filesystemEnvReplacer = regexp.MustCompile(`[^A-Za-z0-9]+`)
+
+func filesystemEnvName(name string) string {
+	return strings.ToUpper(strings.Trim(filesystemEnvReplacer.ReplaceAllString(name, "_"), "_"))
+}
+
+// splitCommandArgs splits a command string into arguments, honoring single/double
+// quotes and backslash escapes.
+func splitCommandArgs(command string) []string {
+	var args []string
+	var current strings.Builder
+	inSingle, inDouble, escaped := false, false, false
+	for _, r := range command {
+		switch {
+		case escaped:
+			current.WriteRune(r)
+			escaped = false
+		case r == '\\' && !inSingle:
+			escaped = true
+		case r == '\'' && !inDouble:
+			inSingle = !inSingle
+		case r == '"' && !inSingle:
+			inDouble = !inDouble
+		case (r == ' ' || r == '\t' || r == '\n') && !inSingle && !inDouble:
+			if current.Len() > 0 {
+				args = append(args, current.String())
+				current.Reset()
+			}
+		default:
+			current.WriteRune(r)
+		}
+	}
+	if current.Len() > 0 {
+		args = append(args, current.String())
+	}
+	return args
+}
+
+type limitedOutputBuffer struct {
+	buf       strings.Builder
+	limit     int
+	truncated bool
+}
+
+func (b *limitedOutputBuffer) Write(p []byte) (int, error) {
+	if b.limit <= 0 {
+		return len(p), nil
+	}
+	remaining := b.limit - b.buf.Len()
+	if remaining <= 0 {
+		b.truncated = true
+		return len(p), nil
+	}
+	if len(p) > remaining {
+		b.truncated = true
+		_, _ = b.buf.Write(p[:remaining])
+		return len(p), nil
+	}
+	_, _ = b.buf.Write(p)
+	return len(p), nil
+}
+
+func (b *limitedOutputBuffer) String() string {
+	out := b.buf.String()
+	if b.truncated {
+		out += fmt.Sprintf("\n[output truncated after %d bytes]", b.limit)
+	}
+	return out
+}
+
+// ---- workspace tools ----
+
+type listInput struct {
+	Root  string  `json:"root"`
+	Path  string  `json:"path"`
+	Glob  string  `json:"glob"`
+	Limit flexInt `json:"limit"`
+}
+
+type listResult struct {
+	Root      string   `json:"root"`
+	Path      string   `json:"path"`
+	Files     []string `json:"files"`
+	Truncated bool     `json:"truncated"`
+}
+
+// NewListWorkspaceFilesHandler lists files under a workspace root, filtered by glob.
+func NewListWorkspaceFilesHandler(ws WorkspaceConfig) ToolHandler {
+	return toolFunc(func(_ context.Context, raw json.RawMessage) (json.RawMessage, error) {
+		var in listInput
+		if err := json.Unmarshal(raw, &in); err != nil {
+			return nil, fmt.Errorf("decode input: %w", err)
+		}
+		root, err := workspaceRootFromInput(ws, in.Root)
+		if err != nil {
+			return nil, err
+		}
+		res, err := listWorkspaceFiles(root, in.Path, in.Glob, applyLimit(int(in.Limit), listDefaultLimit, listMaxLimit))
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(res)
+	})
+}
+
+func listWorkspaceFiles(root WorkspaceRoot, pathValue, pattern string, limit int) (listResult, error) {
+	rootPath := resolvedWorkspaceRootPath(root.Path)
+	startPath, err := safeWorkspacePath(root.Path, defaultString(pathValue, "."))
+	if err != nil {
+		return listResult{}, err
+	}
+	info, err := os.Stat(startPath)
+	if err != nil {
+		return listResult{}, err
+	}
+	if !info.IsDir() {
+		return listResult{}, fmt.Errorf("path is not a directory: %s", pathValue)
+	}
+
+	files := []string{}
+	truncated := false
+	err = filepath.WalkDir(startPath, func(current string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if current == startPath {
+			return nil
+		}
+		if entry.IsDir() && shouldSkipWorkspaceDir(entry.Name()) {
+			return filepath.SkipDir
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(rootPath, current)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if !matchesWorkspacePattern(pattern, rel) {
+			return nil
+		}
+		files = append(files, rel)
+		if limit > 0 && len(files) >= limit {
+			truncated = true
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	if err != nil {
+		return listResult{}, err
+	}
+	return listResult{Root: root.Name, Path: defaultString(pathValue, "."), Files: files, Truncated: truncated}, nil
+}
+
+type readInput struct {
+	Root  string  `json:"root"`
+	Path  string  `json:"path"`
+	Limit flexInt `json:"limit"`
+}
+
+type readResult struct {
+	Root      string `json:"root"`
+	Path      string `json:"path"`
+	Content   string `json:"content"`
+	Truncated bool   `json:"truncated"`
+}
+
+// NewReadWorkspaceFileHandler reads one workspace file (bounded by fileLimit).
+func NewReadWorkspaceFileHandler(ws WorkspaceConfig, fileLimit int) ToolHandler {
+	return toolFunc(func(_ context.Context, raw json.RawMessage) (json.RawMessage, error) {
+		var in readInput
+		if err := json.Unmarshal(raw, &in); err != nil {
+			return nil, fmt.Errorf("decode input: %w", err)
+		}
+		root, err := workspaceRootFromInput(ws, in.Root)
+		if err != nil {
+			return nil, err
+		}
+		if strings.TrimSpace(in.Path) == "" {
+			return nil, fmt.Errorf("missing 'path' parameter")
+		}
+		res, err := readWorkspaceFile(root, in.Path, applyLimit(int(in.Limit), fileLimit, readMaxLimit))
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(res)
+	})
+}
+
+func readWorkspaceFile(root WorkspaceRoot, pathValue string, limit int) (readResult, error) {
+	rootPath := resolvedWorkspaceRootPath(root.Path)
+	fullPath, err := safeWorkspacePath(root.Path, pathValue)
+	if err != nil {
+		return readResult{}, err
+	}
+	info, err := os.Stat(fullPath)
+	if err != nil {
+		return readResult{}, err
+	}
+	if info.IsDir() {
+		return readResult{}, fmt.Errorf("path is a directory: %s", pathValue)
+	}
+	content, truncated, err := readLimitedTextFile(fullPath, limit)
+	if err != nil {
+		return readResult{}, err
+	}
+	rel, _ := filepath.Rel(rootPath, fullPath)
+	return readResult{Root: root.Name, Path: filepath.ToSlash(rel), Content: content, Truncated: truncated}, nil
+}
+
+type searchInput struct {
+	Root       string    `json:"root"`
+	Path       string    `json:"path"`
+	Glob       string    `json:"glob"`
+	Query      string    `json:"query"`
+	IgnoreCase *flexBool `json:"ignoreCase"`
+	Limit      flexInt   `json:"limit"`
+}
+
+type searchMatch struct {
+	Path string `json:"path"`
+	Line int    `json:"line"`
+	Text string `json:"text"`
+}
+
+type searchResult struct {
+	Root      string        `json:"root"`
+	Query     string        `json:"query"`
+	Matches   []searchMatch `json:"matches"`
+	Truncated bool          `json:"truncated"`
+}
+
+// NewSearchWorkspaceHandler does a substring search across a workspace root.
+func NewSearchWorkspaceHandler(ws WorkspaceConfig, fileLimit int) ToolHandler {
+	return toolFunc(func(_ context.Context, raw json.RawMessage) (json.RawMessage, error) {
+		var in searchInput
+		if err := json.Unmarshal(raw, &in); err != nil {
+			return nil, fmt.Errorf("decode input: %w", err)
+		}
+		root, err := workspaceRootFromInput(ws, in.Root)
+		if err != nil {
+			return nil, err
+		}
+		if in.Query == "" {
+			return nil, fmt.Errorf("missing 'query' parameter")
+		}
+		res, err := searchWorkspace(root, in.Path, in.Glob, in.Query,
+			flexBoolValue(in.IgnoreCase, true), applyLimit(int(in.Limit), searchDefaultLimit, searchMaxLimit), fileLimit)
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(res)
+	})
+}
+
+func searchWorkspace(root WorkspaceRoot, pathValue, pattern, query string, ignoreCase bool, limit, fileLimit int) (searchResult, error) {
+	rootPath := resolvedWorkspaceRootPath(root.Path)
+	startPath, err := safeWorkspacePath(root.Path, defaultString(pathValue, "."))
+	if err != nil {
+		return searchResult{}, err
+	}
+	info, err := os.Stat(startPath)
+	if err != nil {
+		return searchResult{}, err
+	}
+	if !info.IsDir() {
+		return searchResult{}, fmt.Errorf("path is not a directory: %s", pathValue)
+	}
+
+	needle := query
+	if ignoreCase {
+		needle = strings.ToLower(needle)
+	}
+	matches := []searchMatch{}
+	truncated := false
+	err = filepath.WalkDir(startPath, func(current string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if current == startPath {
+			return nil
+		}
+		if entry.IsDir() && shouldSkipWorkspaceDir(entry.Name()) {
+			return filepath.SkipDir
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(rootPath, current)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if !matchesWorkspacePattern(pattern, rel) {
+			return nil
+		}
+		content, _, err := readLimitedTextFile(current, fileLimit)
+		if err != nil || strings.Contains(content, "\x00") {
+			return nil
+		}
+		for i, line := range strings.Split(content, "\n") {
+			haystack := line
+			if ignoreCase {
+				haystack = strings.ToLower(haystack)
+			}
+			if strings.Contains(haystack, needle) {
+				matches = append(matches, searchMatch{Path: rel, Line: i + 1, Text: trimLongLine(line, searchLineMax)})
+				if limit > 0 && len(matches) >= limit {
+					truncated = true
+					return filepath.SkipAll
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return searchResult{}, err
+	}
+	return searchResult{Root: root.Name, Query: query, Matches: matches, Truncated: truncated}, nil
+}
+
+type gitStatusInput struct {
+	Root string `json:"root"`
+}
+
+type gitDiffInput struct {
+	Root   string   `json:"root"`
+	Base   string   `json:"base"`
+	Path   string   `json:"path"`
+	Staged flexBool `json:"staged"`
+}
+
+type gitResult struct {
+	Root   string `json:"root"`
+	Output string `json:"output"`
+}
+
+// NewGitStatusHandler runs "git status --short" on a workspace root.
+func NewGitStatusHandler(ws WorkspaceConfig, fileLimit int) ToolHandler {
+	return toolFunc(func(ctx context.Context, raw json.RawMessage) (json.RawMessage, error) {
+		var in gitStatusInput
+		if err := json.Unmarshal(raw, &in); err != nil {
+			return nil, fmt.Errorf("decode input: %w", err)
+		}
+		root, err := workspaceRootFromInput(ws, in.Root)
+		if err != nil {
+			return nil, err
+		}
+		res, err := runGitWorkspaceCommand(ctx, root, []string{"status", "--short"}, fileLimit)
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(res)
+	})
+}
+
+// NewGitDiffHandler runs "git diff" (optionally staged / against a base / for a
+// path) on a workspace root.
+func NewGitDiffHandler(ws WorkspaceConfig, fileLimit int) ToolHandler {
+	return toolFunc(func(ctx context.Context, raw json.RawMessage) (json.RawMessage, error) {
+		var in gitDiffInput
+		if err := json.Unmarshal(raw, &in); err != nil {
+			return nil, fmt.Errorf("decode input: %w", err)
+		}
+		root, err := workspaceRootFromInput(ws, in.Root)
+		if err != nil {
+			return nil, err
+		}
+		args := []string{"diff", "--no-ext-diff", "--color=never"}
+		if bool(in.Staged) {
+			args = append(args, "--cached")
+		}
+		if base := strings.TrimSpace(in.Base); base != "" {
+			args = append(args, base)
+		}
+		if pathValue := strings.TrimSpace(in.Path); pathValue != "" {
+			fullPath, err := safeWorkspacePath(root.Path, pathValue)
+			if err != nil {
+				return nil, err
+			}
+			rel, err := filepath.Rel(resolvedWorkspaceRootPath(root.Path), fullPath)
+			if err != nil {
+				return nil, err
+			}
+			args = append(args, "--", filepath.ToSlash(rel))
+		}
+		res, err := runGitWorkspaceCommand(ctx, root, args, fileLimit)
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(res)
+	})
+}
+
+func runGitWorkspaceCommand(ctx context.Context, root WorkspaceRoot, args []string, limit int) (gitResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, gitCommandTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", root.Path}, args...)...)
+	output := &limitedOutputBuffer{limit: limit}
+	cmd.Stdout = output
+	cmd.Stderr = output
+	err := cmd.Run()
+	out := output.String()
+	if ctx.Err() == context.DeadlineExceeded {
+		return gitResult{}, fmt.Errorf("git command timed out after %s\n%s", gitCommandTimeout, out)
+	}
+	if err != nil {
+		return gitResult{}, fmt.Errorf("git command failed: %w\n%s", err, out)
+	}
+	return gitResult{Root: root.Name, Output: out}, nil
+}
+
+func workspaceRootFromInput(ws WorkspaceConfig, rootName string) (WorkspaceRoot, error) {
+	if root, ok := ws.Root(rootName); ok {
+		return root, nil
+	}
+	names := make([]string, 0, len(ws.Roots))
+	for _, r := range ws.Roots {
+		names = append(names, r.Name)
+	}
+	return WorkspaceRoot{}, fmt.Errorf("unknown filesystem root %q; available: %s", rootName, strings.Join(names, ", "))
+}
+
+// ---- shared helpers ----
+
+// jsonString marshals s as a JSON string (the result form for read_skill_file and
+// script handlers).
+func jsonString(s string) (json.RawMessage, error) {
+	b, err := json.Marshal(s)
+	return b, err
+}
+
+// applyLimit clamps a caller-supplied limit: non-positive falls back to def, and a
+// positive max caps the value (mirrors the original intInput semantics).
+func applyLimit(value, def, max int) int {
+	if value <= 0 {
+		value = def
+	}
+	if max > 0 && value > max {
+		return max
+	}
+	return value
+}
+
+func sortedKeys(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// flexInt decodes a JSON number or numeric string; anything else (including null)
+// decodes to 0, which callers treat as "unset" and replace with a default.
+type flexInt int
+
+func (n *flexInt) UnmarshalJSON(b []byte) error {
+	s := strings.Trim(strings.TrimSpace(string(b)), `"`)
+	if s == "" || s == "null" {
+		*n = 0
+		return nil
+	}
+	if v, err := strconv.Atoi(s); err == nil {
+		*n = flexInt(v)
+		return nil
+	}
+	if f, err := strconv.ParseFloat(s, 64); err == nil {
+		*n = flexInt(int(f))
+		return nil
+	}
+	*n = 0
+	return nil
+}
+
+// flexBool decodes a JSON bool or a "true"/"false" string; anything else is false.
+type flexBool bool
+
+func (b *flexBool) UnmarshalJSON(data []byte) error {
+	s := strings.Trim(strings.TrimSpace(string(data)), `"`)
+	*b = flexBool(s == "true")
+	return nil
+}
+
+// flexBoolValue returns p's value, or def when p is nil (absent).
+func flexBoolValue(p *flexBool, def bool) bool {
+	if p == nil {
+		return def
+	}
+	return bool(*p)
+}

--- a/internal/skillworker/handlers_test.go
+++ b/internal/skillworker/handlers_test.go
@@ -1,0 +1,288 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package skillworker
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func mustWrite(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	full := filepath.Join(dir, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// handle is a test helper that invokes a handler and returns the raw output.
+func handle(t *testing.T, h ToolHandler, input string) (json.RawMessage, error) {
+	t.Helper()
+	return h.Handle(context.Background(), json.RawMessage(input))
+}
+
+// ---- read_skill_file ----
+
+func TestReadSkillFileServesResourceAndSection(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, dir, "references/guide.md", "the guide")
+	h := NewReadSkillFileHandler(dir, []string{"references/guide.md"}, map[string]string{"intro": "## Intro\nbody"})
+
+	out, err := handle(t, h, `{"path":"references/guide.md"}`)
+	if err != nil {
+		t.Fatalf("read resource: %v", err)
+	}
+	if unquote(t, out) != "the guide" {
+		t.Errorf("resource body = %s", out)
+	}
+
+	out, err = handle(t, h, `{"path":"skill_section:intro"}`)
+	if err != nil {
+		t.Fatalf("read section: %v", err)
+	}
+	if unquote(t, out) != "## Intro\nbody" {
+		t.Errorf("section body = %s", out)
+	}
+}
+
+func TestReadSkillFileRejectsUnknownAndTraversal(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, dir, "SKILL.md", "secret")
+	h := NewReadSkillFileHandler(dir, []string{"notes.txt"}, nil)
+
+	// Unknown path → soft ERROR result (task completes), not a hard failure.
+	out, err := handle(t, h, `{"path":"../../etc/passwd"}`)
+	if err != nil {
+		t.Fatalf("unexpected hard error: %v", err)
+	}
+	if !strings.HasPrefix(unquote(t, out), "ERROR:") {
+		t.Errorf("expected ERROR result, got %s", out)
+	}
+
+	// Missing path → hard error (task fails).
+	if _, err := handle(t, h, `{}`); err == nil {
+		t.Error("expected hard error for missing path")
+	}
+}
+
+// TestSafeSkillPathBlocksEscape directly exercises the skill-dir boundary.
+func TestSafeSkillPathBlocksEscape(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := safeSkillPath(dir, "../outside"); err == nil {
+		t.Error("expected traversal to be rejected")
+	}
+	mustWrite(t, dir, "ok.txt", "x")
+	if _, err := safeSkillPath(dir, "ok.txt"); err != nil {
+		t.Errorf("legitimate path rejected: %v", err)
+	}
+}
+
+// ---- workspace: path safety ----
+
+func TestSafeWorkspacePathTraversalAndSymlink(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, root, "inside.txt", "x")
+	if _, err := safeWorkspacePath(root, "inside.txt"); err != nil {
+		t.Errorf("inside path rejected: %v", err)
+	}
+	if _, err := safeWorkspacePath(root, "../escape"); err == nil {
+		t.Error("expected ../escape to be rejected")
+	}
+	if _, err := safeWorkspacePath(root, "/etc/passwd"); err == nil {
+		t.Error("expected absolute path to be rejected")
+	}
+
+	// A symlink pointing outside the root must be rejected.
+	outside := t.TempDir()
+	mustWrite(t, outside, "secret.txt", "top secret")
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(filepath.Join(outside, "secret.txt"), link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if _, err := safeWorkspacePath(root, "link"); err == nil {
+		t.Error("expected symlink escaping the root to be rejected")
+	}
+}
+
+// ---- workspace: list / read / search ----
+
+func TestWorkspaceListReadSearch(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, root, "a.txt", "hello world\nsecond line")
+	mustWrite(t, root, "sub/b.md", "another file with hello")
+	mustWrite(t, root, "node_modules/skip.js", "should be skipped")
+	ws := WorkspaceConfig{Enabled: true, Roots: []WorkspaceRoot{{Name: "workspace", Path: root, Kind: KindWorkspace}}}
+
+	// list
+	out, err := handle(t, NewListWorkspaceFilesHandler(ws), `{}`)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	var lr listResult
+	mustUnmarshal(t, out, &lr)
+	if !containsStr(lr.Files, "a.txt") || !containsStr(lr.Files, "sub/b.md") {
+		t.Errorf("list missing files: %v", lr.Files)
+	}
+	if containsStr(lr.Files, "node_modules/skip.js") {
+		t.Errorf("list should skip node_modules: %v", lr.Files)
+	}
+
+	// read
+	out, err = handle(t, NewReadWorkspaceFileHandler(ws, 1<<20), `{"path":"a.txt"}`)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var rr readResult
+	mustUnmarshal(t, out, &rr)
+	if !strings.Contains(rr.Content, "hello world") {
+		t.Errorf("read content = %q", rr.Content)
+	}
+
+	// search (case-insensitive default) finds matches in both files
+	out, err = handle(t, NewSearchWorkspaceHandler(ws, 1<<20), `{"query":"HELLO"}`)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	var sr searchResult
+	mustUnmarshal(t, out, &sr)
+	if len(sr.Matches) < 2 {
+		t.Errorf("expected >=2 matches, got %d: %+v", len(sr.Matches), sr.Matches)
+	}
+}
+
+func TestWorkspaceUnknownRoot(t *testing.T) {
+	ws := WorkspaceConfig{Enabled: true, Roots: []WorkspaceRoot{{Name: "workspace", Path: t.TempDir(), Kind: KindWorkspace}}}
+	if _, err := handle(t, NewReadWorkspaceFileHandler(ws, 1<<20), `{"root":"nope","path":"x"}`); err == nil {
+		t.Error("expected unknown-root error")
+	}
+}
+
+// ---- scripts ----
+
+func TestScriptHandlerRunsAndLimitsOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script test is POSIX-only")
+	}
+	dir := t.TempDir()
+	mustWrite(t, dir, "SKILL.md", "---\nname: s\n---\nbody")
+	mustWrite(t, dir, "scripts/echo.sh", "#!/bin/bash\necho hello-from-script")
+	scriptPath := filepath.Join(dir, "scripts", "echo.sh")
+
+	out, err := handle(t, NewScriptHandler(scriptPath, LangBash, WorkspaceConfig{}, ScriptOptions{}), `{"command":""}`)
+	if err != nil {
+		t.Fatalf("script: %v", err)
+	}
+	if !strings.Contains(unquote(t, out), "hello-from-script") {
+		t.Errorf("script output = %s", out)
+	}
+
+	// Output limit truncates.
+	limited := NewScriptHandler(scriptPath, LangBash, WorkspaceConfig{}, ScriptOptions{OutputLimit: 4})
+	out, err = handle(t, limited, `{"command":""}`)
+	if err != nil {
+		t.Fatalf("script (limited): %v", err)
+	}
+	if !strings.Contains(unquote(t, out), "output truncated") {
+		t.Errorf("expected truncation marker, got %s", out)
+	}
+}
+
+func TestScriptHandlerTimeoutFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script test is POSIX-only")
+	}
+	dir := t.TempDir()
+	mustWrite(t, dir, "scripts/sleep.sh", "#!/bin/bash\nsleep 5")
+	scriptPath := filepath.Join(dir, "scripts", "sleep.sh")
+
+	_, err := handle(t, NewScriptHandler(scriptPath, LangBash, WorkspaceConfig{}, ScriptOptions{Timeout: 100 * time.Millisecond}), `{"command":""}`)
+	if err == nil {
+		t.Fatal("expected a timeout error")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("error = %v, want a timeout", err)
+	}
+}
+
+// ---- helpers ----
+
+func TestFlexIntAndBoolDecode(t *testing.T) {
+	var li listInput
+	if err := json.Unmarshal([]byte(`{"limit":"250"}`), &li); err != nil {
+		t.Fatal(err)
+	}
+	if int(li.Limit) != 250 {
+		t.Errorf("flexInt string = %d", li.Limit)
+	}
+	if err := json.Unmarshal([]byte(`{"limit":42}`), &li); err != nil {
+		t.Fatal(err)
+	}
+	if int(li.Limit) != 42 {
+		t.Errorf("flexInt number = %d", li.Limit)
+	}
+
+	var gd gitDiffInput
+	if err := json.Unmarshal([]byte(`{"staged":"true"}`), &gd); err != nil {
+		t.Fatal(err)
+	}
+	if !bool(gd.Staged) {
+		t.Error("flexBool string 'true' should decode true")
+	}
+}
+
+func TestApplyLimit(t *testing.T) {
+	if got := applyLimit(0, 500, 5000); got != 500 {
+		t.Errorf("default = %d", got)
+	}
+	if got := applyLimit(10000, 500, 5000); got != 5000 {
+		t.Errorf("cap = %d", got)
+	}
+	if got := applyLimit(300, 500, 5000); got != 300 {
+		t.Errorf("passthrough = %d", got)
+	}
+}
+
+func unquote(t *testing.T, raw json.RawMessage) string {
+	t.Helper()
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		t.Fatalf("output not a JSON string: %s", raw)
+	}
+	return s
+}
+
+func mustUnmarshal(t *testing.T, raw json.RawMessage, v any) {
+	t.Helper()
+	if err := json.Unmarshal(raw, v); err != nil {
+		t.Fatalf("unmarshal %s: %v", raw, err)
+	}
+}
+
+func containsStr(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/skillworker/runner.go
+++ b/internal/skillworker/runner.go
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package skillworker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/antihax/optional"
+	"github.com/conductor-sdk/conductor-go/sdk/client"
+	"github.com/conductor-sdk/conductor-go/sdk/model"
+)
+
+// Poll tuning: one task per poll, with a short server-side long-poll wait. The
+// worker loop adds its own backoff on top (see pollBackoff).
+const (
+	pollBatchSize = 1   // tasks requested per poll
+	pollTimeoutMs = 100 // server-side long-poll wait, milliseconds
+)
+
+// conductorRunner adapts Conductor's TaskResourceApiService to TaskRunner. It is the
+// ONLY place model.* and *client.TaskResourceApiService appear in this package —
+// the worker loop and the handlers see only skillworker.Task and json.RawMessage.
+type conductorRunner struct {
+	client *client.TaskResourceApiService
+}
+
+// NewConductorRunner returns a TaskRunner backed by the Conductor task client
+// (supplied by the cmd layer via internal.GetTaskClient()).
+func NewConductorRunner(taskClient *client.TaskResourceApiService) TaskRunner {
+	return &conductorRunner{client: taskClient}
+}
+
+func (r *conductorRunner) Poll(ctx context.Context, taskType string) (Task, bool, error) {
+	opts := &client.TaskResourceApiBatchPollOpts{
+		Workerid: optional.NewString(workerID),
+		Count:    optional.NewInt32(pollBatchSize),
+		Timeout:  optional.NewInt32(pollTimeoutMs),
+	}
+	tasks, _, err := r.client.BatchPoll(ctx, taskType, opts)
+	if err != nil {
+		return Task{}, false, err
+	}
+	if len(tasks) == 0 {
+		return Task{}, false, nil
+	}
+	return taskFromModel(tasks[0])
+}
+
+func (r *conductorRunner) Complete(ctx context.Context, t Task, output json.RawMessage) error {
+	return r.update(ctx, t, model.CompletedTask, wrapResult(output), "")
+}
+
+func (r *conductorRunner) Fail(ctx context.Context, t Task, reason string) error {
+	return r.update(ctx, t, model.FailedTask, nil, reason)
+}
+
+func (r *conductorRunner) update(ctx context.Context, t Task, status model.TaskResultStatus, output map[string]interface{}, reason string) error {
+	result := &model.TaskResult{
+		TaskId:             t.ID,
+		WorkflowInstanceId: t.WorkflowID,
+		WorkerId:           workerID,
+		Status:             status,
+		OutputData:         output,
+	}
+	if reason != "" {
+		result.ReasonForIncompletion = reason
+	}
+	_, _, err := r.client.UpdateTask(ctx, result)
+	return err
+}
+
+// taskFromModel marshals the SDK task's input map to bytes at the seam, so the
+// map[string]interface{} never crosses into the worker loop or the handlers.
+func taskFromModel(t model.Task) (Task, bool, error) {
+	input, err := json.Marshal(t.InputData)
+	if err != nil {
+		return Task{}, false, fmt.Errorf("marshal task input: %w", err)
+	}
+	return Task{ID: t.TaskId, WorkflowID: t.WorkflowInstanceId, Input: input}, true, nil
+}
+
+// wrapResult wraps a handler's raw output under the "result" key the skill agent
+// expects. Decoding to a generic value happens only here, at the seam.
+func wrapResult(output json.RawMessage) map[string]interface{} {
+	var v interface{}
+	if len(output) > 0 {
+		if err := json.Unmarshal(output, &v); err != nil {
+			v = string(output)
+		}
+	}
+	return map[string]interface{}{outputKeyResult: v}
+}

--- a/internal/skillworker/runner_test.go
+++ b/internal/skillworker/runner_test.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package skillworker
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/conductor-sdk/conductor-go/sdk/model"
+)
+
+// TestTaskFromModelMarshalsInput verifies the bridge maps the SDK task's InputData
+// map to json.RawMessage at the seam (no map crosses into the loop/handlers).
+func TestTaskFromModelMarshalsInput(t *testing.T) {
+	mt := model.Task{
+		TaskId:             "t1",
+		WorkflowInstanceId: "w1",
+		InputData:          map[string]interface{}{"path": "notes.md"},
+	}
+	task, ok, err := taskFromModel(mt)
+	if err != nil || !ok {
+		t.Fatalf("taskFromModel: ok=%v err=%v", ok, err)
+	}
+	if task.ID != "t1" || task.WorkflowID != "w1" {
+		t.Errorf("task ids = %+v", task)
+	}
+	var decoded map[string]string
+	if err := json.Unmarshal(task.Input, &decoded); err != nil {
+		t.Fatalf("input not valid JSON: %v", err)
+	}
+	if decoded["path"] != "notes.md" {
+		t.Errorf("input = %s", task.Input)
+	}
+}
+
+// TestWrapResultWrapsUnderResultKey checks the output wrapping the skill agent
+// expects, for both an object and a bare-string handler output.
+func TestWrapResultWrapsUnderResultKey(t *testing.T) {
+	obj := wrapResult(json.RawMessage(`{"files":["a","b"]}`))
+	inner, ok := obj[outputKeyResult].(map[string]interface{})
+	if !ok {
+		t.Fatalf("result not an object: %#v", obj)
+	}
+	if _, ok := inner["files"]; !ok {
+		t.Errorf("wrapped object lost its fields: %#v", inner)
+	}
+
+	str := wrapResult(json.RawMessage(`"hello"`))
+	if str[outputKeyResult] != "hello" {
+		t.Errorf("string result = %#v", str[outputKeyResult])
+	}
+
+	// Empty output still produces the result key (nil value).
+	empty := wrapResult(nil)
+	if _, ok := empty[outputKeyResult]; !ok {
+		t.Errorf("empty output missing result key: %#v", empty)
+	}
+}

--- a/internal/skillworker/worker.go
+++ b/internal/skillworker/worker.go
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+// Package skillworker is the local tool-worker runtime for skill run/serve. When a
+// skill agent runs on the server, it dispatches tool tasks (read_skill_file, each
+// script, workspace tools) back to the CLI; this package polls for those tasks,
+// runs them locally, and returns the result. It is layered: the poll→handle→update
+// loop and its two interfaces live here, the Conductor SDK is confined to the
+// runner bridge, and the concrete tool logic lives in the handlers (later stage).
+package skillworker
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// Worker protocol constants — fixed by the skill agent/server contract, so they are
+// named constants, never inline literals.
+const (
+	taskTypeSep     = "__"            // task type is "{skillName}__{tool}"
+	outputKeyResult = "result"        // handler output is wrapped as {result: <output>}
+	workerID        = "conductor-cli" // identifies this worker in task results
+)
+
+// pollBackoff is the idle wait between polls that return no task or an error. The
+// production runner also long-polls the server, so this is a hot-loop backstop.
+const pollBackoff = 100 * time.Millisecond
+
+// TaskType builds the "{skillName}__{tool}" task type dispatched for a skill tool.
+func TaskType(skillName, tool string) string {
+	return skillName + taskTypeSep + tool
+}
+
+// ToolHandler handles one dispatched tool task. IO is json.RawMessage, so no map
+// crosses this boundary; the concrete tool logic lives in the handlers.
+type ToolHandler interface {
+	Handle(ctx context.Context, input json.RawMessage) (json.RawMessage, error)
+}
+
+// Task is one polled tool task, decoupled from the SDK's model.Task.
+type Task struct {
+	ID         string
+	WorkflowID string
+	Input      json.RawMessage
+}
+
+// TaskRunner is the poll/complete/fail seam. The production impl (runner.go) wraps
+// Conductor's TaskResourceApiService; tests inject a fake. It keeps model.Task and
+// *client.TaskResourceApiService out of the worker loop and the handlers.
+type TaskRunner interface {
+	// Poll returns the next task for taskType. ok=false means no task was available
+	// (poll again); a non-nil err is a real polling failure.
+	Poll(ctx context.Context, taskType string) (task Task, ok bool, err error)
+	Complete(ctx context.Context, t Task, output json.RawMessage) error
+	Fail(ctx context.Context, t Task, reason string) error
+}
+
+// Worker runs the poll→handle→update loop for a single task type over a TaskRunner.
+type Worker struct {
+	runner TaskRunner
+}
+
+// NewWorker returns a Worker backed by the given TaskRunner.
+func NewWorker(runner TaskRunner) *Worker {
+	return &Worker{runner: runner}
+}
+
+// Run polls taskType and dispatches each task to h until ctx is cancelled. Transient
+// poll failures back off and retry rather than stop the loop; a handler error fails
+// only that task. Run returns when ctx is done.
+func (w *Worker) Run(ctx context.Context, taskType string, h ToolHandler) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		task, ok, err := w.runner.Poll(ctx, taskType)
+		if err != nil {
+			if !sleep(ctx, pollBackoff) {
+				return
+			}
+			continue
+		}
+		if !ok {
+			if !sleep(ctx, pollBackoff) {
+				return
+			}
+			continue
+		}
+
+		output, handleErr := h.Handle(ctx, task.Input)
+		if handleErr != nil {
+			_ = w.runner.Fail(ctx, task, handleErr.Error())
+			continue
+		}
+		_ = w.runner.Complete(ctx, task, output)
+	}
+}
+
+// sleep waits d or until ctx is cancelled; it returns false if ctx was cancelled,
+// which keeps the poll loop responsive to Ctrl-C during idle waits.
+func sleep(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}

--- a/internal/skillworker/worker_test.go
+++ b/internal/skillworker/worker_test.go
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package skillworker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// handlerFunc adapts a function to ToolHandler.
+type handlerFunc func(ctx context.Context, input json.RawMessage) (json.RawMessage, error)
+
+func (f handlerFunc) Handle(ctx context.Context, input json.RawMessage) (json.RawMessage, error) {
+	return f(ctx, input)
+}
+
+// fakeRunner is a TaskRunner that returns queued tasks then reports empty polls. It
+// records terminal updates and can cancel the loop once the queue is drained.
+type fakeRunner struct {
+	mu           sync.Mutex
+	queue        []Task
+	pollCount    int
+	completed    []completedCall
+	failed       []failedCall
+	stopAfterOne context.CancelFunc // cancel the loop after the first terminal update
+}
+
+type completedCall struct {
+	task   Task
+	output json.RawMessage
+}
+
+type failedCall struct {
+	task   Task
+	reason string
+}
+
+func (r *fakeRunner) Poll(ctx context.Context, taskType string) (Task, bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.pollCount++
+	if len(r.queue) == 0 {
+		return Task{}, false, nil
+	}
+	t := r.queue[0]
+	r.queue = r.queue[1:]
+	return t, true, nil
+}
+
+func (r *fakeRunner) Complete(ctx context.Context, t Task, output json.RawMessage) error {
+	r.mu.Lock()
+	r.completed = append(r.completed, completedCall{task: t, output: output})
+	r.mu.Unlock()
+	if r.stopAfterOne != nil {
+		r.stopAfterOne()
+	}
+	return nil
+}
+
+func (r *fakeRunner) Fail(ctx context.Context, t Task, reason string) error {
+	r.mu.Lock()
+	r.failed = append(r.failed, failedCall{task: t, reason: reason})
+	r.mu.Unlock()
+	if r.stopAfterOne != nil {
+		r.stopAfterOne()
+	}
+	return nil
+}
+
+func TestWorkerRunCompletesTask(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	fr := &fakeRunner{
+		queue:        []Task{{ID: "t1", WorkflowID: "w1", Input: json.RawMessage(`{"path":"a"}`)}},
+		stopAfterOne: cancel,
+	}
+	var gotInput json.RawMessage
+	h := handlerFunc(func(_ context.Context, in json.RawMessage) (json.RawMessage, error) {
+		gotInput = in
+		return json.RawMessage(`"file body"`), nil
+	})
+
+	NewWorker(fr).Run(ctx, "demo__read_skill_file", h)
+
+	if string(gotInput) != `{"path":"a"}` {
+		t.Errorf("handler input = %s", gotInput)
+	}
+	if len(fr.completed) != 1 || len(fr.failed) != 0 {
+		t.Fatalf("completed=%d failed=%d", len(fr.completed), len(fr.failed))
+	}
+	got := fr.completed[0]
+	if got.task.ID != "t1" || string(got.output) != `"file body"` {
+		t.Errorf("completed call = %+v", got)
+	}
+}
+
+func TestWorkerRunFailsTaskOnHandlerError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	fr := &fakeRunner{
+		queue:        []Task{{ID: "t2", WorkflowID: "w2"}},
+		stopAfterOne: cancel,
+	}
+	h := handlerFunc(func(context.Context, json.RawMessage) (json.RawMessage, error) {
+		return nil, errors.New("boom")
+	})
+
+	NewWorker(fr).Run(ctx, "demo__script", h)
+
+	if len(fr.failed) != 1 || len(fr.completed) != 0 {
+		t.Fatalf("completed=%d failed=%d", len(fr.completed), len(fr.failed))
+	}
+	if fr.failed[0].reason != "boom" || fr.failed[0].task.ID != "t2" {
+		t.Errorf("fail call = %+v", fr.failed[0])
+	}
+}
+
+func TestWorkerRunStopsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	fr := &fakeRunner{} // always reports empty polls
+	done := make(chan struct{})
+	go func() {
+		NewWorker(fr).Run(ctx, "demo__x", handlerFunc(func(context.Context, json.RawMessage) (json.RawMessage, error) {
+			return nil, nil
+		}))
+		close(done)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not stop after context cancel")
+	}
+}
+
+func TestTaskType(t *testing.T) {
+	if got := TaskType("demo", "read_skill_file"); got != "demo__read_skill_file" {
+		t.Errorf("TaskType = %q", got)
+	}
+}

--- a/internal/skillworker/workspace.go
+++ b/internal/skillworker/workspace.go
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package skillworker
+
+import (
+	"fmt"
+	"io"
+	"os"
+	pathpkg "path"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Workspace root kinds and the reserved default root name.
+const (
+	KindWorkspace     = "workspace"  // the primary, editable working directory
+	KindFilesystem    = "filesystem" // an additional named read-only root
+	workspaceRootName = "workspace"  // Root("") and AGENTSPAN_WORKSPACE_DIR resolve to this
+)
+
+// defaultTextReadLimit bounds a single text read when no limit is supplied.
+const defaultTextReadLimit = 1 << 20 // 1 MiB
+
+// workspaceRootNamePattern constrains a root name to a filesystem/env-safe set.
+var workspaceRootNamePattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
+// WorkspaceConfig is the set of local roots the workspace tools expose. It is
+// resolved from flags in the cmd layer and passed to the handlers; the server only
+// ever sees the wire form (WireConfig) and tool outputs, never these paths.
+type WorkspaceConfig struct {
+	Enabled bool
+	Roots   []WorkspaceRoot
+}
+
+// WorkspaceRoot is one named, absolute, symlink-resolved local root.
+type WorkspaceRoot struct {
+	Name string
+	Path string
+	Kind string
+}
+
+// WorkspaceWire is the workspace section of a skill config as sent to the server:
+// the enable flag and the root names/kinds only — never their local paths.
+type WorkspaceWire struct {
+	Enabled bool                `json:"enabled"`
+	Roots   []WorkspaceRootWire `json:"roots,omitempty"`
+}
+
+// WorkspaceRootWire is one named workspace root on the wire (no path).
+type WorkspaceRootWire struct {
+	Name string `json:"name"`
+	Kind string `json:"kind,omitempty"`
+}
+
+// NewWorkspaceRoot validates and resolves one root. The name must be
+// filesystem/env-safe and the path must be an existing directory; the returned
+// path is absolute and symlink-resolved. File I/O is expected here — this is the
+// local CLI runtime layer.
+func NewWorkspaceRoot(name, pathValue, kind string) (WorkspaceRoot, error) {
+	if !workspaceRootNamePattern.MatchString(name) {
+		return WorkspaceRoot{}, fmt.Errorf("invalid filesystem root name %q: use letters, numbers, dot, underscore, or dash", name)
+	}
+	absPath, err := filepath.Abs(pathValue)
+	if err != nil {
+		return WorkspaceRoot{}, fmt.Errorf("resolve filesystem root %q: %w", name, err)
+	}
+	info, err := os.Stat(absPath)
+	if err != nil {
+		return WorkspaceRoot{}, fmt.Errorf("filesystem root %q does not exist: %w", name, err)
+	}
+	if !info.IsDir() {
+		return WorkspaceRoot{}, fmt.Errorf("filesystem root %q is not a directory: %s", name, absPath)
+	}
+	if resolved, err := filepath.EvalSymlinks(absPath); err == nil {
+		absPath = resolved
+	}
+	return WorkspaceRoot{Name: name, Path: absPath, Kind: kind}, nil
+}
+
+// Root returns the named root, or the first root for an empty name.
+func (c WorkspaceConfig) Root(name string) (WorkspaceRoot, bool) {
+	if name == "" && len(c.Roots) > 0 {
+		return c.Roots[0], true
+	}
+	for _, root := range c.Roots {
+		if root.Name == name {
+			return root, true
+		}
+	}
+	return WorkspaceRoot{}, false
+}
+
+// WireConfig produces the server-bound workspace section (no local paths), or nil
+// when the workspace is disabled.
+func (c WorkspaceConfig) WireConfig() *WorkspaceWire {
+	if !c.Enabled {
+		return nil
+	}
+	roots := make([]WorkspaceRootWire, 0, len(c.Roots))
+	for _, r := range c.Roots {
+		roots = append(roots, WorkspaceRootWire{Name: r.Name, Kind: r.Kind})
+	}
+	return &WorkspaceWire{Enabled: true, Roots: roots}
+}
+
+// safeWorkspacePath joins relPath onto absRoot and rejects any path that escapes
+// the root (after resolving symlinks) — the workspace security boundary.
+func safeWorkspacePath(absRoot, relPath string) (string, error) {
+	cleanRel := filepath.Clean(filepath.FromSlash(defaultString(relPath, ".")))
+	if filepath.IsAbs(cleanRel) || cleanRel == ".." || strings.HasPrefix(cleanRel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("'%s' is outside the filesystem root", relPath)
+	}
+	target := filepath.Join(absRoot, cleanRel)
+	resolvedRoot, err := filepath.EvalSymlinks(absRoot)
+	if err != nil {
+		resolvedRoot = absRoot
+	}
+	resolvedTarget, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		resolvedTarget = target
+	}
+	if rel, err := filepath.Rel(resolvedRoot, resolvedTarget); err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("'%s' is outside the filesystem root", relPath)
+	}
+	return resolvedTarget, nil
+}
+
+// resolvedWorkspaceRootPath returns absRoot with symlinks resolved (used to compute
+// relative paths consistently with safeWorkspacePath's resolved targets).
+func resolvedWorkspaceRootPath(absRoot string) string {
+	if resolved, err := filepath.EvalSymlinks(absRoot); err == nil {
+		return resolved
+	}
+	return absRoot
+}
+
+// readLimitedTextFile reads up to limit bytes and reports whether it truncated.
+func readLimitedTextFile(pathValue string, limit int) (string, bool, error) {
+	if limit <= 0 {
+		limit = defaultTextReadLimit
+	}
+	file, err := os.Open(pathValue)
+	if err != nil {
+		return "", false, err
+	}
+	defer file.Close()
+	data, err := io.ReadAll(io.LimitReader(file, int64(limit)+1))
+	if err != nil {
+		return "", false, err
+	}
+	truncated := len(data) > limit
+	if truncated {
+		data = data[:limit]
+	}
+	return string(data), truncated, nil
+}
+
+// shouldSkipWorkspaceDir reports directories the workspace walk never descends into.
+func shouldSkipWorkspaceDir(name string) bool {
+	switch name {
+	case ".git", "node_modules", "__pycache__", ".venv", "venv", ".tox", "dist", "build", "target", ".gradle", ".idea", ".mypy_cache", ".pytest_cache":
+		return true
+	default:
+		return false
+	}
+}
+
+// matchesWorkspacePattern reports whether relPath matches a glob (supporting **),
+// or true when the pattern is empty.
+func matchesWorkspacePattern(pattern, relPath string) bool {
+	pattern = filepath.ToSlash(strings.TrimSpace(pattern))
+	if pattern == "" {
+		return true
+	}
+	relPath = filepath.ToSlash(relPath)
+	if ok, err := pathpkg.Match(pattern, relPath); err == nil && ok {
+		return true
+	}
+	if strings.Contains(pattern, "**") {
+		re := regexp.QuoteMeta(pattern)
+		re = strings.ReplaceAll(re, `\*\*`, `.*`)
+		re = strings.ReplaceAll(re, `\*`, `[^/]*`)
+		re = strings.ReplaceAll(re, `\?`, `[^/]`)
+		ok, err := regexp.MatchString("^"+re+"$", relPath)
+		return err == nil && ok
+	}
+	if strings.HasPrefix(pattern, "*") || strings.HasSuffix(pattern, "*") {
+		return strings.Contains(relPath, strings.Trim(pattern, "*"))
+	}
+	return relPath == pattern
+}
+
+// trimLongLine caps a line length for search-match display.
+func trimLongLine(value string, limit int) string {
+	if limit <= 0 || len(value) <= limit {
+		return value
+	}
+	return value[:limit] + "...[truncated]"
+}
+
+// defaultString returns fallback when value is blank.
+func defaultString(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+// Package transport is the shared HTTP transport for the agent and skill clients.
+// Those endpoints are not part of the conductor-go SDK, so the CLI owns a small,
+// interface-bounded transport that reuses Conductor's resolved server URL and JWT
+// (see cmd/root.go) — one backend, one auth path. No file paths, ports, or URLs are
+// hardcoded here: BaseURL comes from config and request lifetime from the context.
+package transport
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// authHeader is the header Conductor uses to carry the bearer JWT. It matches the
+// conductor-go SDK (sdk/client/http_requester.go) and the merged server's auth filter.
+const authHeader = "X-Authorization"
+
+// TokenProvider yields the current JWT for the X-Authorization header. An empty
+// string with a nil error means anonymous access — the header is omitted.
+type TokenProvider interface {
+	Token(ctx context.Context) (string, error)
+}
+
+// Config is the shared transport for agent and skill traffic. BaseURL and Tokens are
+// resolved once at startup from the same source as the conductor-go client, so these
+// calls reuse Conductor's server URL and authentication — no second config, no second
+// auth path.
+type Config struct {
+	BaseURL string
+	Tokens  TokenProvider // nil => anonymous
+	HTTP    *http.Client  // nil => defaultClient
+}
+
+// defaultClient has no timeout on purpose: request lifetime is governed by the
+// caller's context, which also keeps long-lived SSE streams open until cancelled.
+var defaultClient = &http.Client{}
+
+func (c Config) httpClient() *http.Client {
+	if c.HTTP != nil {
+		return c.HTTP
+	}
+	return defaultClient
+}
+
+// Do builds and executes a request against BaseURL+path. It attaches the
+// X-Authorization header (when a token is available) plus any extra headers, then
+// returns the response unchanged for a 2xx status, or a normalized *APIError for a
+// non-2xx status (whose body it consumes). On success the caller owns closing
+// resp.Body, which makes Do equally suitable for streaming (SSE) responses.
+func (c Config) Do(ctx context.Context, method, path string, body io.Reader, header http.Header) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, c.BaseURL+path, body)
+	if err != nil {
+		return nil, err
+	}
+	for k, vs := range header {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
+	}
+	if err := c.applyAuth(ctx, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return nil, newAPIError(method, path, resp) // consumes & closes the body
+	}
+	return resp, nil
+}
+
+// DoJSON marshals reqBody (when non-nil) as JSON, executes the request, and decodes a
+// 2xx response into respBody (when non-nil). Pass a *json.RawMessage as respBody to
+// capture the raw payload without imposing a schema across the layer boundary.
+func (c Config) DoJSON(ctx context.Context, method, path string, reqBody, respBody any) error {
+	var body io.Reader
+	header := http.Header{}
+	if reqBody != nil {
+		data, err := json.Marshal(reqBody)
+		if err != nil {
+			return fmt.Errorf("encode request body: %w", err)
+		}
+		body = bytes.NewReader(data)
+		header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.Do(ctx, method, path, body, header)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if respBody == nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(respBody); err != nil {
+		return fmt.Errorf("decode response body: %w", err)
+	}
+	return nil
+}
+
+func (c Config) applyAuth(ctx context.Context, req *http.Request) error {
+	if c.Tokens == nil {
+		return nil
+	}
+	tok, err := c.Tokens.Token(ctx)
+	if err != nil {
+		return fmt.Errorf("resolve auth token: %w", err)
+	}
+	if tok != "" {
+		req.Header.Set(authHeader, tok)
+	}
+	return nil
+}
+
+// APIError is a non-2xx response from the Conductor server. It mirrors the server's
+// JSON error shape ({status, message, error}) so agent and skill errors read
+// consistently with the rest of the CLI (cf. cmd.parseAPIError, which does the same
+// for SDK-surfaced errors).
+type APIError struct {
+	Status  int
+	Method  string
+	Path    string
+	Message string
+}
+
+func (e *APIError) Error() string {
+	if e.Message != "" {
+		return fmt.Sprintf("%s (status %d)", e.Message, e.Status)
+	}
+	return fmt.Sprintf("%s %s failed with status %d", e.Method, e.Path, e.Status)
+}
+
+// newAPIError reads and closes resp.Body and builds an *APIError from it.
+func newAPIError(method, path string, resp *http.Response) *APIError {
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+
+	apiErr := &APIError{Status: resp.StatusCode, Method: method, Path: path}
+
+	var parsed struct {
+		Message string `json:"message"`
+		Error   string `json:"error"`
+	}
+	if json.Unmarshal(raw, &parsed) == nil {
+		switch {
+		case parsed.Message != "":
+			apiErr.Message = parsed.Message
+		case parsed.Error != "":
+			apiErr.Message = parsed.Error
+		}
+	}
+	if apiErr.Message == "" {
+		apiErr.Message = strings.TrimSpace(string(raw))
+	}
+	return apiErr
+}

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package transport
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type staticToken string
+
+func (s staticToken) Token(context.Context) (string, error) { return string(s), nil }
+
+func TestDoJSONSetsAuthHeaderAndRoundTrips(t *testing.T) {
+	var gotAuth, gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get(authHeader)
+		gotMethod = r.Method
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"abc"}`))
+	}))
+	defer srv.Close()
+
+	c := Config{BaseURL: srv.URL, Tokens: staticToken("jwt-123")}
+	var out struct {
+		ID string `json:"id"`
+	}
+	if err := c.DoJSON(context.Background(), http.MethodGet, "/x", nil, &out); err != nil {
+		t.Fatalf("DoJSON: %v", err)
+	}
+	if gotAuth != "jwt-123" {
+		t.Errorf("X-Authorization = %q, want jwt-123", gotAuth)
+	}
+	if gotMethod != http.MethodGet {
+		t.Errorf("method = %q, want GET", gotMethod)
+	}
+	if out.ID != "abc" {
+		t.Errorf("id = %q, want abc", out.ID)
+	}
+}
+
+func TestDoOmitsAuthHeaderWhenAnonymous(t *testing.T) {
+	var hadAuth bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, hadAuth = r.Header[authHeader]
+	}))
+	defer srv.Close()
+
+	c := Config{BaseURL: srv.URL} // no Tokens => anonymous
+	resp, err := c.Do(context.Background(), http.MethodGet, "/x", nil, nil)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	_ = resp.Body.Close()
+	if hadAuth {
+		t.Error("expected no X-Authorization header for anonymous transport")
+	}
+}
+
+func TestDoNormalizesServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"status":404,"message":"agent not found"}`))
+	}))
+	defer srv.Close()
+
+	c := Config{BaseURL: srv.URL}
+	_, err := c.Do(context.Background(), http.MethodGet, "/api/agent/x", nil, nil)
+	if err == nil {
+		t.Fatal("expected an error for a 404 response")
+	}
+	apiErr, ok := err.(*APIError)
+	if !ok {
+		t.Fatalf("error type = %T, want *APIError", err)
+	}
+	if apiErr.Status != http.StatusNotFound || apiErr.Message != "agent not found" {
+		t.Errorf("got %+v, want status 404 / message 'agent not found'", apiErr)
+	}
+}


### PR DESCRIPTION
## What

Folds the standalone AgentSpan CLI into the `conductor` binary as first‑class subcommands, talking to the single merged Conductor server. The old AgentSpan runtime on `:6767` is retired and never referenced — the server comes only from `--server` / `CONDUCTOR_SERVER_URL`.

- **`conductor agent`** — `compile`, `delete`, `execution`, `get`, `init`, `list`, `prune`, `respond`, `run` (SSE), `status`, `stream`.
- **`conductor skill`** — `delete`, `get`, `list`, `pull`, `register`, `load`, `run` (streams), `serve`.

## Not migrated

- **Dropped (superseded by Conductor):** `login` / `logout`, `configure` → Conductor auth (`config save`, key/secret→JWT) and the existing `secret` store; `version` → root `--version`.
- **Name collisions (Conductor's command wins):** `server` (`start` / `stop` / `logs` / `ps`) and `update` — these managed the retired `:6767` runtime / JAR. AgentSpan's data-op `server prune` **survives, rehomed as `agent prune`**.
- **Deferred (in scope):** `tui`, `credentials` (+ `set` / `bind` / `bindings`)

## Followups

- `tui`
- `credentials` (+ `set` / `bind` / `bindings`)
