### PR TITLE
fix: agent compile posts a bare config instead of the agentConfig envelope

### DIFF
--- a/internal/agent/client.go
+++ b/internal/agent/client.go
@@ -258,9 +258,11 @@ func (c *restClient) Delete(ctx context.Context, name string, version *int) erro
 	return c.doJSON(ctx, http.MethodDelete, agentPath(name, version), nil, nil)
 }
 
+// Compile asks the server to compile a config into a WorkflowDef without registering
+// or running it.
 func (c *restClient) Compile(ctx context.Context, def json.RawMessage) (json.RawMessage, error) {
 	var out json.RawMessage
-	if err := c.doJSON(ctx, http.MethodPost, pathCompile, def, &out); err != nil {
+	if err := c.doJSON(ctx, http.MethodPost, pathCompile, startRequest{AgentConfig: def}, &out); err != nil {
 		return nil, err
 	}
 	return out, nil

--- a/test/e2e/agent.bats
+++ b/test/e2e/agent.bats
@@ -181,6 +181,7 @@ run_bounded() {
 # {"agentConfig": ...}, so compile fails for every input.
 # bats test_tags=tier:pr
 @test "12. Agent compile returns an execution plan" {
+    require_agents_api
     write_agent_config "$BATS_TEST_TMPDIR/compile.yaml"
     run bash -c "./conductor agent compile '$BATS_TEST_TMPDIR/compile.yaml' 2>&1"
     echo "Output: $output"

--- a/test/e2e/agent.bats
+++ b/test/e2e/agent.bats
@@ -181,7 +181,6 @@ run_bounded() {
 # {"agentConfig": ...}, so compile fails for every input.
 # bats test_tags=tier:pr
 @test "12. Agent compile returns an execution plan" {
-    skip "known broken: #96 — CLI sends a bare config, server rejects it"
     write_agent_config "$BATS_TEST_TMPDIR/compile.yaml"
     run bash -c "./conductor agent compile '$BATS_TEST_TMPDIR/compile.yaml' 2>&1"
     echo "Output: $output"


### PR DESCRIPTION
Fixes #96.

`agent compile` fails for every config:

```
./conductor agent compile foo.yaml
Error: agentConfig is required when framework is not specified (status 400)
```

`/agent/compile` expects `AgentStartRequest`. `Compile` posted the bare config, which deserialized to an empty request. 


## How to test

```bash
go build -o conductor .
./conductor agent init foo --model openai/gpt-4o
./conductor agent compile foo.yaml   # prints the compiled workflowDef
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
