### PR TITLE
fix: filter agent executions with a structured startTime query (#97)

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -176,16 +177,17 @@ Time formats for --since and --window: 30s, 5m, 1h, 6h, 1d, 7d, 1mo, 1y`,
 		if err != nil {
 			return err
 		}
-		freeText, err := buildExecutionFreeText(execSince, execWindow)
+		from, to, err := buildExecutionWindow(execSince, execWindow)
 		if err != nil {
 			return err
 		}
 		page, err := internal.GetAgentService().SearchExecutions(cmd.Context(), agent.ExecutionFilter{
-			AgentName: execName,
-			Status:    execStatus,
-			FreeText:  freeText,
-			Start:     0,
-			Size:      defaultExecutionSearchSize,
+			AgentName:     execName,
+			Status:        execStatus,
+			StartTimeFrom: from,
+			StartTimeTo:   to,
+			Start:         0,
+			Size:          defaultExecutionSearchSize,
 		})
 		if err != nil {
 			return err
@@ -413,38 +415,28 @@ func formatMillis(ms int64) string {
 	return (time.Duration(ms) * time.Millisecond).String()
 }
 
-// buildExecutionFreeText converts the --since / --window flags into the server's
-// freeText time-range query.
-func buildExecutionFreeText(since, window string) (string, error) {
-	freeText := ""
+// buildExecutionWindow resolves --since / --window into epoch-ms bounds, where zero
+// means unbounded. Given both, the windows intersect: the later lower bound wins.
+func buildExecutionWindow(since, window string) (from, to int64, err error) {
+	now := time.Now()
 	if since != "" {
 		dur, err := parseTimeSpec(since)
 		if err != nil {
-			return "", fmt.Errorf("invalid --since value: %w", err)
+			return 0, 0, fmt.Errorf("invalid --since value: %w", err)
 		}
-		start := time.Now().Add(-dur).UnixMilli()
-		freeText = fmt.Sprintf("startTime:[%d TO *]", start)
+		from = now.Add(-dur).UnixMilli()
 	}
 	if window != "" {
-		spec := window
-		const relativePrefix = "now-"
-		if len(spec) > len(relativePrefix) && spec[:len(relativePrefix)] == relativePrefix {
-			spec = spec[len(relativePrefix):]
-		}
-		dur, err := parseTimeSpec(spec)
+		dur, err := parseTimeSpec(strings.TrimPrefix(window, "now-"))
 		if err != nil {
-			return "", fmt.Errorf("invalid --window value: %w", err)
+			return 0, 0, fmt.Errorf("invalid --window value: %w", err)
 		}
-		end := time.Now().UnixMilli()
-		start := time.Now().Add(-dur).UnixMilli()
-		q := fmt.Sprintf("startTime:[%d TO %d]", start, end)
-		if freeText != "" {
-			freeText += " AND " + q
-		} else {
-			freeText = q
+		if start := now.Add(-dur).UnixMilli(); start > from {
+			from = start
 		}
+		to = now.UnixMilli()
 	}
-	return freeText, nil
+	return from, to, nil
 }
 
 var timeSpecPattern = regexp.MustCompile(`^(\d+)(s|m|h|d|mo|y)$`)

--- a/cmd/agent_execution_window_test.go
+++ b/cmd/agent_execution_window_test.go
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package cmd
+
+import (
+	"testing"
+	"time"
+)
+
+// Absorbs the clock ticking between the call and the assertion.
+const windowTolerance = int64(2000)
+
+func assertNear(t *testing.T, label string, got, want int64) {
+	t.Helper()
+	if diff := got - want; diff > windowTolerance || diff < -windowTolerance {
+		t.Errorf("%s = %d, want ~%d (diff %d ms)", label, got, want, diff)
+	}
+}
+
+func TestBuildExecutionWindowSince(t *testing.T) {
+	now := time.Now()
+	from, to, err := buildExecutionWindow("1h", "")
+	if err != nil {
+		t.Fatalf("buildExecutionWindow: %v", err)
+	}
+	assertNear(t, "from", from, now.Add(-time.Hour).UnixMilli())
+	if to != 0 {
+		t.Errorf("to = %d, want 0 (unbounded)", to)
+	}
+}
+
+func TestBuildExecutionWindowRelativePrefix(t *testing.T) {
+	now := time.Now()
+	from, to, err := buildExecutionWindow("", "now-7d")
+	if err != nil {
+		t.Fatalf("buildExecutionWindow: %v", err)
+	}
+	assertNear(t, "from", from, now.Add(-7*24*time.Hour).UnixMilli())
+	assertNear(t, "to", to, now.UnixMilli())
+}
+
+func TestBuildExecutionWindowWithoutPrefix(t *testing.T) {
+	now := time.Now()
+	from, _, err := buildExecutionWindow("", "30m")
+	if err != nil {
+		t.Fatalf("buildExecutionWindow: %v", err)
+	}
+	assertNear(t, "from", from, now.Add(-30*time.Minute).UnixMilli())
+}
+
+func TestBuildExecutionWindowBothFlagsIntersect(t *testing.T) {
+	now := time.Now()
+	from, to, err := buildExecutionWindow("7d", "now-1h")
+	if err != nil {
+		t.Fatalf("buildExecutionWindow: %v", err)
+	}
+	assertNear(t, "from", from, now.Add(-time.Hour).UnixMilli())
+	assertNear(t, "to", to, now.UnixMilli())
+}
+
+func TestBuildExecutionWindowNoFlags(t *testing.T) {
+	from, to, err := buildExecutionWindow("", "")
+	if err != nil {
+		t.Fatalf("buildExecutionWindow: %v", err)
+	}
+	if from != 0 || to != 0 {
+		t.Errorf("from/to = %d/%d, want 0/0", from, to)
+	}
+}
+
+func TestBuildExecutionWindowInvalidValues(t *testing.T) {
+	if _, _, err := buildExecutionWindow("yesterday", ""); err == nil {
+		t.Error("--since yesterday: got nil error, want error")
+	}
+	if _, _, err := buildExecutionWindow("", "now-lately"); err == nil {
+		t.Error("--window now-lately: got nil error, want error")
+	}
+}

--- a/internal/agent/client.go
+++ b/internal/agent/client.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/conductor-oss/conductor-cli/internal/transport"
 )
@@ -32,6 +33,8 @@ import (
 // prefix (see cmd/root.go) — mirroring the conductor-go SDK, whose base is also
 // ".../api" and whose resource paths omit it. Do not re-add "/api" here.
 const (
+	pathWorkflowSearch = "/workflow/search" // execution search; see SearchExecutions
+
 	pathAgents     = "/agent"                  // base; "/{name}" appended
 	pathStart      = "/agent/start"            //
 	pathDeploy     = "/agent/deploy"           // publish/activate without starting
@@ -53,9 +56,15 @@ const (
 	queryAgentName     = "agentName"
 	queryStatus        = "status"
 	queryFreeText      = "freeText"
+	queryQuery         = "query"
+	queryClassifier    = "classifier"
+	queryTopLevelOnly  = "topLevelOnly"
 	queryOlderThanDays = "olderThanDays"
 	queryArchiveTasks  = "archiveTasks"
 	sortExecutions     = "startTime:DESC"
+	freeTextAll        = "*"
+	classifierAgent    = "agent"
+	quoteChars         = `'"`
 	valueTrue          = "true"
 )
 
@@ -266,25 +275,93 @@ func (c *restClient) Compile(ctx context.Context, def json.RawMessage) (json.Raw
 	return out, nil
 }
 
+// SearchExecutions returns one page of agent executions matching filter, newest
+// first. It searches /workflow/search scoped to classifier=agent, because
+// /agent/executions cannot filter on startTime (#97).
 func (c *restClient) SearchExecutions(ctx context.Context, filter ExecutionFilter) (ExecutionPage, error) {
+	clauses, err := executionQueryClauses(filter)
+	if err != nil {
+		return ExecutionPage{}, err
+	}
 	q := url.Values{}
 	q.Set(queryStart, strconv.Itoa(filter.Start))
 	q.Set(querySize, strconv.Itoa(filter.Size))
 	q.Set(querySort, sortExecutions)
-	if filter.AgentName != "" {
-		q.Set(queryAgentName, filter.AgentName)
+	q.Set(queryFreeText, freeTextAll)
+	q.Set(queryClassifier, classifierAgent)
+	q.Set(queryTopLevelOnly, valueTrue)
+	if clauses != "" {
+		q.Set(queryQuery, clauses)
 	}
-	if filter.Status != "" {
-		q.Set(queryStatus, filter.Status)
-	}
-	if filter.FreeText != "" {
-		q.Set(queryFreeText, filter.FreeText)
-	}
-	var page ExecutionPage
-	if err := c.doJSON(ctx, http.MethodGet, pathExecutions+"?"+q.Encode(), nil, &page); err != nil {
+
+	var result workflowSearchResult
+	if err := c.doJSON(ctx, http.MethodGet, pathWorkflowSearch+"?"+q.Encode(), nil, &result); err != nil {
 		return ExecutionPage{}, err
 	}
-	return page, nil
+	return result.toExecutionPage(), nil
+}
+
+// executionQueryClauses renders filter as a Conductor search expression, e.g.
+// "workflowType='triage' AND startTime>1786120404085". Returns "" for an empty
+// filter, and an error if a value contains a quote.
+func executionQueryClauses(filter ExecutionFilter) (string, error) {
+	var clauses []string
+	if filter.AgentName != "" {
+		if strings.ContainsAny(filter.AgentName, quoteChars) {
+			return "", fmt.Errorf("agent name must not contain quotes: %q", filter.AgentName)
+		}
+		clauses = append(clauses, fmt.Sprintf("workflowType='%s'", filter.AgentName))
+	}
+	if filter.Status != "" {
+		if strings.ContainsAny(filter.Status, quoteChars) {
+			return "", fmt.Errorf("status must not contain quotes: %q", filter.Status)
+		}
+		clauses = append(clauses, fmt.Sprintf("status='%s'", filter.Status))
+	}
+	// ">=" is rejected by both query parsers with a 500.
+	if filter.StartTimeFrom > 0 {
+		clauses = append(clauses, fmt.Sprintf("startTime>%d", filter.StartTimeFrom))
+	}
+	if filter.StartTimeTo > 0 {
+		clauses = append(clauses, fmt.Sprintf("startTime<%d", filter.StartTimeTo))
+	}
+	return strings.Join(clauses, " AND "), nil
+}
+
+// workflowSearchResult decodes the fields the execution list needs from the
+// SearchResult<WorkflowSummary> returned by /workflow/search.
+type workflowSearchResult struct {
+	TotalHits int64 `json:"totalHits"`
+	Results   []struct {
+		WorkflowID    string `json:"workflowId"`
+		WorkflowType  string `json:"workflowType"`
+		Version       int    `json:"version"`
+		Status        string `json:"status"`
+		StartTime     string `json:"startTime"`
+		EndTime       string `json:"endTime"`
+		ExecutionTime int64  `json:"executionTime"`
+		Classifier    string `json:"classifier"`
+	} `json:"results"`
+}
+
+func (r workflowSearchResult) toExecutionPage() ExecutionPage {
+	page := ExecutionPage{TotalHits: r.TotalHits}
+	for _, w := range r.Results {
+		// A server that ignores the classifier param returns plain workflows too.
+		if w.Classifier != "" && w.Classifier != classifierAgent {
+			continue
+		}
+		page.Results = append(page.Results, ExecutionSummary{
+			ExecutionID:   w.WorkflowID,
+			AgentName:     w.WorkflowType,
+			Version:       w.Version,
+			Status:        w.Status,
+			StartTime:     w.StartTime,
+			EndTime:       w.EndTime,
+			ExecutionTime: w.ExecutionTime,
+		})
+	}
+	return page
 }
 
 func (c *restClient) GetExecution(ctx context.Context, id string) (json.RawMessage, error) {

--- a/internal/agent/client_test.go
+++ b/internal/agent/client_test.go
@@ -19,6 +19,8 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/conductor-oss/conductor-cli/internal/transport"
@@ -141,14 +143,23 @@ func TestDeployNormalizesErrorResponse(t *testing.T) {
 
 func TestSearchExecutionsSetsQuery(t *testing.T) {
 	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != pathWorkflowSearch {
+			t.Errorf("path = %q, want %q", r.URL.Path, pathWorkflowSearch)
+		}
 		q := r.URL.Query()
-		if q.Get(queryAgentName) != "greeter" || q.Get(queryStatus) != "FAILED" {
-			t.Errorf("query = %v", q)
+		if got, want := q.Get(queryQuery), "workflowType='greeter' AND status='FAILED'"; got != want {
+			t.Errorf("query = %q, want %q", got, want)
+		}
+		if q.Get(queryClassifier) != classifierAgent || q.Get(queryTopLevelOnly) != valueTrue {
+			t.Errorf("scope params = %v", q)
+		}
+		if q.Get(queryFreeText) != freeTextAll {
+			t.Errorf("freeText = %q, want %q", q.Get(queryFreeText), freeTextAll)
 		}
 		if q.Get(querySort) != sortExecutions {
 			t.Errorf("sort = %q, want %q", q.Get(querySort), sortExecutions)
 		}
-		_, _ = w.Write([]byte(`{"totalHits":1,"results":[{"executionId":"e1","status":"FAILED"}]}`))
+		_, _ = w.Write([]byte(`{"totalHits":1,"results":[{"workflowId":"e1","workflowType":"greeter","status":"FAILED","classifier":"agent"}]}`))
 	})
 	page, err := c.SearchExecutions(context.Background(), ExecutionFilter{
 		AgentName: "greeter", Status: "FAILED", Size: 10,
@@ -156,8 +167,82 @@ func TestSearchExecutionsSetsQuery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SearchExecutions: %v", err)
 	}
-	if page.TotalHits != 1 || len(page.Results) != 1 || page.Results[0].ExecutionID != "e1" {
-		t.Errorf("page = %+v", page)
+	if page.TotalHits != 1 || len(page.Results) != 1 {
+		t.Fatalf("page = %+v", page)
+	}
+	if got := page.Results[0]; got.ExecutionID != "e1" || got.AgentName != "greeter" {
+		t.Errorf("result = %+v, want executionId e1 / agentName greeter", got)
+	}
+}
+
+// Regression guard for #97: the time range must ride in "query", not "freeText".
+func TestSearchExecutionsSendsStartTimeAsStructuredQuery(t *testing.T) {
+	var got url.Values
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		got = r.URL.Query()
+		_, _ = w.Write([]byte(`{"totalHits":0,"results":[]}`))
+	})
+	if _, err := c.SearchExecutions(context.Background(), ExecutionFilter{
+		StartTimeFrom: 1786120404085, StartTimeTo: 1786124004085, Size: 10,
+	}); err != nil {
+		t.Fatalf("SearchExecutions: %v", err)
+	}
+	if want := "startTime>1786120404085 AND startTime<1786124004085"; got.Get(queryQuery) != want {
+		t.Errorf("query = %q, want %q", got.Get(queryQuery), want)
+	}
+	if strings.Contains(got.Get(queryFreeText), "startTime") {
+		t.Errorf("freeText = %q, must not carry the time range", got.Get(queryFreeText))
+	}
+}
+
+func TestExecutionQueryClauses(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter ExecutionFilter
+		want   string
+	}{
+		{"empty", ExecutionFilter{}, ""},
+		{"since only", ExecutionFilter{StartTimeFrom: 5}, "startTime>5"},
+		{"window", ExecutionFilter{StartTimeFrom: 5, StartTimeTo: 9}, "startTime>5 AND startTime<9"},
+		{"name and time", ExecutionFilter{AgentName: "triage", StartTimeFrom: 5}, "workflowType='triage' AND startTime>5"},
+		{"status", ExecutionFilter{Status: "FAILED"}, "status='FAILED'"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := executionQueryClauses(tt.filter)
+			if err != nil {
+				t.Fatalf("executionQueryClauses: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExecutionQueryClausesRejectsQuotedValues(t *testing.T) {
+	for _, f := range []ExecutionFilter{
+		{AgentName: `x' OR status='FAILED`},
+		{Status: `x"`},
+	} {
+		if _, err := executionQueryClauses(f); err == nil {
+			t.Errorf("executionQueryClauses(%+v) = nil error, want error", f)
+		}
+	}
+}
+
+func TestSearchExecutionsDropsNonAgentResults(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"totalHits":2,"results":[
+			{"workflowId":"a1","workflowType":"triage","classifier":"agent"},
+			{"workflowId":"w1","workflowType":"order_flow","classifier":"workflow"}]}`))
+	})
+	page, err := c.SearchExecutions(context.Background(), ExecutionFilter{Size: 10})
+	if err != nil {
+		t.Fatalf("SearchExecutions: %v", err)
+	}
+	if len(page.Results) != 1 || page.Results[0].ExecutionID != "a1" {
+		t.Errorf("results = %+v, want only the agent execution", page.Results)
 	}
 }
 

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -57,12 +57,14 @@ type AgentSummary struct {
 }
 
 // ExecutionFilter narrows an execution search. Start/Size paginate.
+// StartTimeFrom/StartTimeTo are epoch milliseconds; zero means unbounded.
 type ExecutionFilter struct {
-	AgentName string
-	Status    string
-	FreeText  string
-	Start     int
-	Size      int
+	AgentName     string
+	Status        string
+	StartTimeFrom int64
+	StartTimeTo   int64
+	Start         int
+	Size          int
 }
 
 // ExecutionPage is one page of execution-search results.

--- a/test/e2e/agent.bats
+++ b/test/e2e/agent.bats
@@ -241,11 +241,10 @@ run_bounded() {
     [ "$status_val" != "RUNNING" ]
 }
 
-# Regression guard for #97: --since and --window return nothing even when
-# matching executions exist.
+# Regression guard for #97: --since and --window returned nothing even when
+# matching executions existed.
 # bats test_tags=tier:nightly,needs:llm
 @test "16. Agent execution --since finds a just-created execution" {
-    skip "known broken: #97 — --since/--window always return no results"
     require_llm
     write_agent_config "$BATS_TEST_TMPDIR/run4.yaml"
     ./conductor agent run --config "$BATS_TEST_TMPDIR/run4.yaml" "Reply with one word" --no-stream >/dev/null 2>&1
@@ -254,6 +253,27 @@ run_bounded() {
     echo "Output: $output"
     [ "$status" -eq 0 ]
     [[ "$output" != *"No executions found"* ]]
+}
+
+# The wide window alone passes even when the server ignores the bound. The narrow
+# window is the half that fails in that case.
+# bats test_tags=tier:nightly,needs:llm
+@test "16b. Agent execution time filter excludes executions outside the window" {
+    require_llm
+    write_agent_config "$BATS_TEST_TMPDIR/run4b.yaml"
+    ./conductor agent run --config "$BATS_TEST_TMPDIR/run4b.yaml" "Reply with one word" --no-stream >/dev/null 2>&1
+
+    run bash -c "./conductor agent execution --window now-7d 2>&1"
+    echo "Wide window output: $output"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"No executions found"* ]]
+
+    # The execution above is now outside the window.
+    sleep 6
+    run bash -c "./conductor agent execution --since 2s 2>&1"
+    echo "Narrow window output: $output"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"No executions found"* ]]
 }
 
 # Regression guard for #102: agent stream never exits once the execution is


### PR DESCRIPTION
## Issue

Every time-filtered search was empty while the unfiltered one listed rows - #97.

## What changed

`agent execution --since/--window` built `freeText=startTime:[<ms> TO *]`. 

- SQLite turns `freeText` into `json_data LIKE '%startTime:[…]%'`, which never matches.
- Elasticsearch passes it to `queryStringQuery` and returns 0.

Search now goes through `/workflow/search` with `classifier=agent&topLevelOnly=true`. **Same as Conductor UI on Agent Executions view.**

**Why not `/agent/executions`?** That endpoint builds its search query internally and exposes no time-range parameter. A caller-supplied `query` is ignored.

## How to test

```
conductor agent run --config agent.yaml "hi" --no-stream
conductor agent execution --since 1h        # was empty, now lists the run
conductor agent execution --window now-7d
conductor agent execution --name <agent> --since 1d
sleep 6 && conductor agent execution --since 2s   # correctly empty
```

## Review notes

- **`>` only.** `>=` is rejected by both query parsers with a 500 (`For input string: "=<ms>"`), because neither defines the operator.
- **Quoted values are rejected.** Values are embedded as `field='value'`. A value containing a quote would change what the expression means, so it errors instead.
- **Non-agent rows are dropped.** A server whose index predates the `classifier` field ignores the filter and returns plain workflows. The mapper skips rows whose `classifier` is not `agent`.
- **The SDK cannot express this.** `WorkflowResourceApiSearchOpts` has no `classifier` or `topLevelOnly`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
