### PR TITLE
ci: stop overwriting the release notes with a commit list

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,11 +58,10 @@ jobs:
         chmod +x dist/conductor_*
 
     - name: Create Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
-        # No `body`/`body_path` — it would overwrite the notes on a published draft.
-        # This only applies when the step creates the release itself.
-        generate_release_notes: true
+        # No `body`/`body_path` and no `generate_release_notes`: the notes are
+        # written by whoever cuts the release. This step only uploads the binaries.
         files: |
           dist/conductor_linux_amd64
           dist/conductor_linux_arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,28 +57,12 @@ jobs:
         # Make binaries executable
         chmod +x dist/conductor_*
 
-    - name: Generate changelog
-      id: changelog
-      run: |
-        # Get the previous tag
-        PREV_TAG=$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1) 2>/dev/null || echo "")
-
-        if [ -z "$PREV_TAG" ]; then
-          # First release - use all commits
-          CHANGELOG=$(git log --pretty=format:"- %s (%h)" --no-merges)
-        else
-          # Get commits since previous tag
-          CHANGELOG=$(git log ${PREV_TAG}..HEAD --pretty=format:"- %s (%h)" --no-merges)
-        fi
-
-        # Write changelog to file
-        echo "$CHANGELOG" > CHANGELOG.txt
-        cat CHANGELOG.txt
-
     - name: Create Release
       uses: softprops/action-gh-release@v1
       with:
-        body_path: CHANGELOG.txt
+        # No `body`/`body_path` — it would overwrite the notes on a published draft.
+        # This only applies when the step creates the release itself.
+        generate_release_notes: true
         files: |
           dist/conductor_linux_amd64
           dist/conductor_linux_arm64


### PR DESCRIPTION
## What

The release job made a `CHANGELOG.txt` from `git log` and gave it to `action-gh-release` as `body_path`. The job then replaces the notes with a raw list of commits.

## Change

- Remove the `Generate changelog` step and `body_path`.
- Bump `softprops/action-gh-release` from `v1` to `v2`. `v1` runs on Node 16, which is deprecated.

The step now only uploads the binaries. It never touches the body.

## How to test

Cut a test tag, or watch the next release. The notes should stay as written.