### PR TITLE
fix: make the default config writable and stop merging env vars with config files (#98)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,9 @@ installing (CLI only). Diagnose with `which conductor` and `brew info --cask con
 
 ## Authentication
 
-**Three methods** (precedence: command-line flags > environment variables > config file):
+**Three methods.** Command-line flags override individual settings. Below them, credentials come
+from a single source — the environment or a config file, never both at once (see
+[Profile Management](#profile-management)):
 
 | Method | Command-line Flags | Environment Variables |
 |--------|-------------------|----------------------|
@@ -85,11 +87,20 @@ profile name and `--profile default` both mean `~/.conductor-cli/config.yaml`, f
 `delete` and profile selection alike. The CLI never creates `config-default.yaml`; if one exists
 from an older build it is ignored, and `config list`/`config show` warn that it is unused.
 
-**Environment variables and the default config merge, key by key.** With no profile selected,
-both are live: an environment variable wins for the key it sets, and `config.yaml` still supplies
-every key the environment leaves unset. Selecting a *named* profile turns the environment off
-entirely, so the profile wins. Run `conductor config show` to see which source produced each
-value.
+**Configuration comes from exactly one source, never a mix.** Below command-line flags, which
+override individual settings, the CLI picks a single source and uses it for everything:
+
+| Condition | Source |
+|-----------|--------|
+| `--config <path>` or `--profile <name>` given | That file. Environment variables are ignored. |
+| Any `CONDUCTOR_*` setting variable is set | The environment. `config.yaml` is **not read**. |
+| Neither | `~/.conductor-cli/config.yaml` |
+
+Setting one variable therefore switches the whole configuration onto the environment: if
+`CONDUCTOR_SERVER_URL` is set and `config.yaml` holds an auth token, that token is *not* used.
+`CONDUCTOR_PROFILE` does not count — it selects a file rather than carrying a setting.
+
+Run `conductor config show` to see the active source and where each value came from.
 
 ## Command Reference
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,16 +87,21 @@ profile name and `--profile default` both mean `~/.conductor-cli/config.yaml`, f
 `delete` and profile selection alike. The CLI never creates `config-default.yaml`; if one exists
 from an older build it is ignored, and `config list`/`config show` warn that it is unused.
 
+**Two kinds of flag.** *Value* flags carry a setting: `--server`, `--server-type`, `--auth-key`,
+`--auth-secret`, `--auth-token`. *Selector* flags carry no setting and only choose which file to
+read: `--config <path>`, `--profile <name>`.
+
 **Precedence, highest first:**
 
-1. Command-line flags (`--server`, `--auth-token`, ...) — applied per setting
-2. A named file: `--config <path>` or `--profile <name>`
+1. Value flags — applied per setting
+2. The file named by `--config` or `--profile`
 3. Environment variables (`CONDUCTOR_SERVER_URL`, `CONDUCTOR_AUTH_TOKEN`, ...)
 4. `~/.conductor-cli/config.yaml`
 5. Built-in defaults
 
 **Levels 2-4 are winner-takes-all.** The highest one present supplies *every* setting, and the
-levels below it are not consulted at all — they never merge. Only flags layer on top per setting.
+levels below it are not consulted at all — they never merge. Only value flags layer on top, per
+setting.
 
 | Condition | Source |
 |-----------|--------|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,27 +87,22 @@ profile name and `--profile default` both mean `~/.conductor-cli/config.yaml`, f
 `delete` and profile selection alike. The CLI never creates `config-default.yaml`; if one exists
 from an older build it is ignored, and `config list`/`config show` warn that it is unused.
 
-**Two kinds of flag.** *Value* flags carry a setting: `--server`, `--server-type`, `--auth-key`,
-`--auth-secret`, `--auth-token`. *Selector* flags carry no setting and only choose which file to
-read: `--config <path>`, `--profile <name>`.
+**Precedence.** Rank 1 wins over rank 2, rank 2 over rank 3, and so on.
 
-**Precedence, highest first:**
+| Rank | Source | Example |
+|------|--------|---------|
+| 1 | Command-line value flags | `--server`, `--auth-token` |
+| 2 | File chosen by `--config` or `--profile` | `--profile prod` reads `config-prod.yaml` |
+| 3 | Environment variables | `CONDUCTOR_SERVER_URL` |
+| 4 | Default config file | `~/.conductor-cli/config.yaml` |
+| 5 | Built-in defaults | `server-type: OSS` |
 
-1. Value flags — applied per setting
-2. The file named by `--config` or `--profile`
-3. Environment variables (`CONDUCTOR_SERVER_URL`, `CONDUCTOR_AUTH_TOKEN`, ...)
-4. `~/.conductor-cli/config.yaml`
-5. Built-in defaults
+Ranks 2-4 are winner-takes-all: only the highest one present is used, and it supplies *every*
+setting. The ranks below it are not read. Rank 1 is different — it applies per setting, so
+`--server` overrides only the server URL.
 
-**Levels 2-4 are winner-takes-all.** The highest one present supplies *every* setting, and the
-levels below it are not consulted at all — they never merge. Only value flags layer on top, per
-setting.
-
-| Condition | Source |
-|-----------|--------|
-| `--config <path>` or `--profile <name>` given | That file. Environment variables are ignored. |
-| Any `CONDUCTOR_*` setting variable is set | The environment. `config.yaml` is **not read**. |
-| Neither | `~/.conductor-cli/config.yaml` |
+`--config` and `--profile` are not rank 1. They carry no settings; they only choose the file in
+rank 2.
 
 Setting one variable therefore switches the whole configuration onto the environment: if
 `CONDUCTOR_SERVER_URL` is set and `config.yaml` holds an auth token, that token is *not* used.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,21 +68,28 @@ Manage multiple environments (dev, staging, prod) using profiles.
 | Operation | Command | Result |
 |-----------|---------|--------|
 | **Save named profile** | `conductor config save --profile prod` | Creates `~/.conductor-cli/config-prod.yaml` |
-| **Save (prompted)** | `conductor config save` | Prompts `Profile name:`, then creates `config-<name>.yaml` |
+| **Save default** | `conductor config save` | Prompts `Profile name (empty for default):`; Enter creates `config.yaml` |
+| **Save default (no prompt)** | `conductor config save --profile default` | Creates `config.yaml` |
 | **Use profile (flag)** | `conductor --profile prod workflow list` | Loads `config-prod.yaml` |
 | **Use profile (env)** | `CONDUCTOR_PROFILE=prod conductor workflow list` | Loads `config-prod.yaml` |
+| **Inspect what is active** | `conductor config show` | Prints each value and where it came from |
 
 **Precedence:** `--profile` flag > `CONDUCTOR_PROFILE` env var > default config
 
 **Profile directory:** `~/.conductor-cli/`
-- `config.yaml` - default profile
+- `config.yaml` - default configuration
 - `config-<name>.yaml` - named profiles
 
-**`config save` always writes a named profile.** It has no code path that creates the default
-`config.yaml` — without `--profile` it prompts for a name and errors if the name is empty. An
-existing `config.yaml` is still *loaded* as the default, but cannot be created or updated through
-the CLI (see conductor-cli issue #98). To use the default config, write `~/.conductor-cli/config.yaml`
-by hand.
+**`default` is an alias for the default configuration, not a profile of its own.** An empty
+profile name and `--profile default` both mean `~/.conductor-cli/config.yaml`, for `save`,
+`delete` and profile selection alike. The CLI never creates `config-default.yaml`; if one exists
+from an older build it is ignored, and `config list`/`config show` warn that it is unused.
+
+**Environment variables and the default config merge, key by key.** With no profile selected,
+both are live: an environment variable wins for the key it sets, and `config.yaml` still supplies
+every key the environment leaves unset. Selecting a *named* profile turns the environment off
+entirely, so the profile wins. Run `conductor config show` to see which source produced each
+value.
 
 ## Command Reference
 
@@ -192,12 +199,17 @@ Columns: NAME, EXECUTABLE, DESCRIPTION, OWNER, TIMEOUT POLICY, TIMEOUT (s), RETR
 |---------|-------------|---------------|----------------|---------|
 | `config save` | Interactively save configuration | None | `--profile` | `conductor config save` or `conductor config save --profile production` |
 | `config list` | List all configuration profiles | None | None | `conductor config list` |
+| `config show` | Show the effective config and each value's source | None | `--json`, `--show-secrets` | `conductor config show` |
 | `config delete [profile]` | Delete configuration file | None | `--profile`, `-y` | `conductor config delete production` or `conductor config delete --profile production -y` |
 
 **Notes:**
-- `config save`: Interactive prompts for server URL, server type, and authentication method. Press Enter to keep existing values. Always saves to a named profile `config-<name>.yaml`; `--profile <name>` supplies the name, and without it the command prompts for one (empty input is an error). It cannot write the default `config.yaml`.
+- `config save`: Interactive prompts for server URL, server type, and authentication method. Press Enter to keep existing values. `--profile <name>` writes `config-<name>.yaml`; an empty name at the prompt, or `--profile default`, writes the default `config.yaml`.
 - `config list`: Shows all profiles. Default config shown as "default", named profiles show as profile name only.
-- `config delete`: Profile can be specified as positional arg or via `--profile` flag. Use `-y` to skip confirmation prompt.
+- `config show`: Prints `KEY`, `VALUE` and `SOURCE` for every setting, where source is the flag, the environment variable, the config file, or `default`. Secrets are masked unless `--show-secrets` is passed.
+- `config delete`: Profile can be specified as positional arg or via `--profile` flag. Use `default` to delete the default `config.yaml`. Use `-y` to skip confirmation prompt.
+
+**Table Output (config show):**
+Columns: KEY, VALUE, SOURCE
 
 ### Webhook Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,9 @@ from an older build it is ignored, and `config list`/`config show` warn that it 
 So exporting `CONDUCTOR_SERVER_URL` switches everything onto the environment. A token in
 `config.yaml` is no longer used.
 
+`CONDUCTOR_PROFILE` is different. It selects which file to read, so it does not switch the CLI to
+the environment.
+
 Setting one variable therefore switches the whole configuration onto the environment: if
 `CONDUCTOR_SERVER_URL` is set and `config.yaml` holds an auth token, that token is *not* used.
 `CONDUCTOR_PROFILE` does not count — it selects a file rather than carrying a setting.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,22 +87,21 @@ profile name and `--profile default` both mean `~/.conductor-cli/config.yaml`, f
 `delete` and profile selection alike. The CLI never creates `config-default.yaml`; if one exists
 from an older build it is ignored, and `config list`/`config show` warn that it is unused.
 
-**Precedence.** Rank 1 wins over rank 2, rank 2 over rank 3, and so on.
+**Where settings come from.** The CLI uses the first source in this list:
 
-| Rank | Source | Example |
-|------|--------|---------|
-| 1 | Command-line value flags | `--server`, `--auth-token` |
-| 2 | File chosen by `--config` or `--profile` | `--profile prod` reads `config-prod.yaml` |
+| Order | Source | Example |
+|-------|--------|---------|
+| 1 | Flags | `--server`, `--auth-token` |
+| 2 | The file from `--config` or `--profile` | `--profile prod` reads `config-prod.yaml` |
 | 3 | Environment variables | `CONDUCTOR_SERVER_URL` |
-| 4 | Default config file | `~/.conductor-cli/config.yaml` |
+| 4 | The default config file | `~/.conductor-cli/config.yaml` |
 | 5 | Built-in defaults | `server-type: OSS` |
 
-Ranks 2-4 are winner-takes-all: only the highest one present is used, and it supplies *every*
-setting. The ranks below it are not read. Rank 1 is different — it applies per setting, so
-`--server` overrides only the server URL.
+That source supplies all settings. The CLI does not read the sources below it.
 
-`--config` and `--profile` are not rank 1. They carry no settings; they only choose the file in
-rank 2.
+A flag is different. It changes only its own setting.
+
+`--config` and `--profile` do not hold settings. They select the file on line 2.
 
 Setting one variable therefore switches the whole configuration onto the environment: if
 `CONDUCTOR_SERVER_URL` is set and `config.yaml` holds an auth token, that token is *not* used.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,8 +87,16 @@ profile name and `--profile default` both mean `~/.conductor-cli/config.yaml`, f
 `delete` and profile selection alike. The CLI never creates `config-default.yaml`; if one exists
 from an older build it is ignored, and `config list`/`config show` warn that it is unused.
 
-**Configuration comes from exactly one source, never a mix.** Below command-line flags, which
-override individual settings, the CLI picks a single source and uses it for everything:
+**Precedence, highest first:**
+
+1. Command-line flags (`--server`, `--auth-token`, ...) — applied per setting
+2. A named file: `--config <path>` or `--profile <name>`
+3. Environment variables (`CONDUCTOR_SERVER_URL`, `CONDUCTOR_AUTH_TOKEN`, ...)
+4. `~/.conductor-cli/config.yaml`
+5. Built-in defaults
+
+**Levels 2-4 are winner-takes-all.** The highest one present supplies *every* setting, and the
+levels below it are not consulted at all — they never merge. Only flags layer on top per setting.
 
 | Condition | Source |
 |-----------|--------|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ profile name and `--profile default` both mean `~/.conductor-cli/config.yaml`, f
 `delete` and profile selection alike. The CLI never creates `config-default.yaml`; if one exists
 from an older build it is ignored, and `config list`/`config show` warn that it is unused.
 
-**Where settings come from.** The CLI uses the first source in this list:
+**Configuration comes from exactly one source, never a mix.** Flags override individual settings.
 
 | Order | Source | Example |
 |-------|--------|---------|
@@ -95,13 +95,9 @@ from an older build it is ignored, and `config list`/`config show` warn that it 
 | 2 | The file from `--config` or `--profile` | `--profile prod` reads `config-prod.yaml` |
 | 3 | Environment variables | `CONDUCTOR_SERVER_URL` |
 | 4 | The default config file | `~/.conductor-cli/config.yaml` |
-| 5 | Built-in defaults | `server-type: OSS` |
 
-That source supplies all settings. The CLI does not read the sources below it.
-
-A flag is different. It changes only its own setting.
-
-`--config` and `--profile` do not hold settings. They select the file on line 2.
+So exporting `CONDUCTOR_SERVER_URL` switches everything onto the environment. A token in
+`config.yaml` is no longer used.
 
 Setting one variable therefore switches the whole configuration onto the environment: if
 `CONDUCTOR_SERVER_URL` is set and `config.yaml` holds an auth token, that token is *not* used.

--- a/README.md
+++ b/README.md
@@ -755,16 +755,20 @@ auth-secret   -                           default
 auth-token    ****                        config.yaml
 ```
 
+There are two kinds of flag. *Value* flags carry a setting: `--server`, `--server-type`,
+`--auth-key`, `--auth-secret`, `--auth-token`. *Selector* flags carry no setting and only choose
+which file to read: `--config <path>`, `--profile <name>`.
+
 Precedence, highest first:
 
-1. Command-line flags (`--server`, `--auth-token`, ...) — applied per setting
-2. A named file: `--config <path>` or `--profile <name>`
+1. Value flags — applied per setting
+2. The file named by `--config` or `--profile`
 3. Environment variables (`CONDUCTOR_SERVER_URL`, `CONDUCTOR_AUTH_TOKEN`, ...)
 4. `~/.conductor-cli/config.yaml`
 5. Built-in defaults
 
 Levels 2-4 are winner-takes-all: the highest one present supplies *every* setting, and the levels
-below it are not consulted at all. They never merge. Only flags layer on top per setting.
+below it are not consulted at all. They never merge. Only value flags layer on top, per setting.
 
 | Condition | Source |
 |-----------|--------|

--- a/README.md
+++ b/README.md
@@ -755,8 +755,16 @@ auth-secret   -                           default
 auth-token    ****                        config.yaml
 ```
 
-Configuration comes from exactly one source, never a mix of two. Command-line flags override
-individual settings; below them the CLI picks a single source:
+Precedence, highest first:
+
+1. Command-line flags (`--server`, `--auth-token`, ...) — applied per setting
+2. A named file: `--config <path>` or `--profile <name>`
+3. Environment variables (`CONDUCTOR_SERVER_URL`, `CONDUCTOR_AUTH_TOKEN`, ...)
+4. `~/.conductor-cli/config.yaml`
+5. Built-in defaults
+
+Levels 2-4 are winner-takes-all: the highest one present supplies *every* setting, and the levels
+below it are not consulted at all. They never merge. Only flags layer on top per setting.
 
 | Condition | Source |
 |-----------|--------|

--- a/README.md
+++ b/README.md
@@ -627,6 +627,7 @@ If a configuration already exists, you can press Enter to keep existing values (
 conductor config save
 
 # Example interaction:
+# Profile name (empty for default): ← Press Enter for ~/.conductor-cli/config.yaml
 # Server URL [http://localhost:8080/api]: https://developer.conductorcloud.com
 # Server type (OSS/Enterprise) [Enterprise]: ← Press Enter to keep
 #
@@ -733,11 +734,37 @@ This shows:
 - `default` - for the default `config.yaml` file
 - Profile names (e.g., `production`, `staging`) - for named profiles like `config-production.yaml`
 
+`default` is an alias for `config.yaml`, so `--profile default` and an empty profile name select
+the same file. The CLI never creates a `config-default.yaml`.
+
+**Seeing which settings are actually in effect:**
+
+```bash
+conductor config show
+```
+
+```
+Profile: default
+File:    /Users/you/.conductor-cli/config.yaml
+
+KEY           VALUE                      SOURCE
+server        http://from-env:9999/api   env CONDUCTOR_SERVER_URL
+server-type   OSS                        config.yaml
+auth-key      -                          default
+auth-secret   -                          default
+auth-token    ****                       config.yaml
+```
+
+Environment variables and the default config merge key by key: the environment wins for the keys
+it sets, and the config file supplies the rest. Selecting a named profile with `--profile` turns
+the environment off, so the profile wins. Secrets are masked unless you pass `--show-secrets`;
+`--json` prints the same data for scripts.
+
 **Deleting Profiles:**
 
 ```bash
-# Delete default config (with confirmation prompt)
-conductor config delete
+# Delete the default config (with confirmation prompt)
+conductor config delete default
 
 # Delete named profile
 conductor config delete production

--- a/README.md
+++ b/README.md
@@ -744,8 +744,7 @@ conductor config show
 ```
 
 ```
-Profile: default
-Source:  /Users/you/.conductor-cli/config.yaml
+Source: /Users/you/.conductor-cli/config.yaml
 
 KEY           VALUE                       SOURCE
 server        http://localhost:8080/api   config.yaml
@@ -755,21 +754,11 @@ auth-secret   -                           default
 auth-token    ****                        config.yaml
 ```
 
-Configuration comes from exactly one source, never a mix. Flags override individual settings.
-
-| Order | Source | Example |
-|-------|--------|---------|
-| 1 | Flags | `--server`, `--auth-token` |
-| 2 | The file from `--config` or `--profile` | `--profile prod` reads `config-prod.yaml` |
-| 3 | Environment variables | `CONDUCTOR_SERVER_URL` |
-| 4 | The default config file | `~/.conductor-cli/config.yaml` |
-
-So exporting `CONDUCTOR_SERVER_URL` switches the whole configuration onto the environment — an
-auth token sitting in `config.yaml` is not used, and `config show` says so:
+When an environment variable is set, the config file is not read at all — see
+[Configuration Precedence](#configuration-precedence):
 
 ```
-Profile: default
-Source:  environment variables (config file not read)
+Source: environment variables (config file not read)
 
 KEY           VALUE                      SOURCE
 server        http://from-env:9999/api   env CONDUCTOR_SERVER_URL
@@ -803,11 +792,17 @@ conductor --profile nonexistent workflow list
 
 ### Configuration Precedence
 
-The CLI can be configured using command-line flags, environment variables, or a configuration file. Configuration is handled with the following precedence (highest to lowest):
+Configuration comes from exactly one source, never a mix. Flags override individual settings.
 
-1. Command-line flags
-2. Environment variables
-3. Configuration file
+| Order | Source | Example |
+|-------|--------|---------|
+| 1 | Flags | `--server`, `--auth-token` |
+| 2 | The file from `--config` or `--profile` | `--profile prod` reads `config-prod.yaml` |
+| 3 | Environment variables | `CONDUCTOR_SERVER_URL` |
+| 4 | The default config file | `~/.conductor-cli/config.yaml` |
+
+So exporting `CONDUCTOR_SERVER_URL` switches everything onto the environment. A token in
+`config.yaml` is not used. Run `conductor config show` to see the active source.
 
 ### Command-line Flags
 

--- a/README.md
+++ b/README.md
@@ -758,7 +758,7 @@ When an environment variable is set, the config file is not read at all — see
 [Configuration Precedence](#configuration-precedence):
 
 ```
-Source: environment variables (config file not read)
+Source: environment variables
 
 KEY           VALUE                      SOURCE
 server        http://from-env:9999/api   env CONDUCTOR_SERVER_URL

--- a/README.md
+++ b/README.md
@@ -755,7 +755,7 @@ auth-secret   -                           default
 auth-token    ****                        config.yaml
 ```
 
-The CLI uses the first source in this list:
+Configuration comes from exactly one source, never a mix. Flags override individual settings.
 
 | Order | Source | Example |
 |-------|--------|---------|
@@ -763,13 +763,6 @@ The CLI uses the first source in this list:
 | 2 | The file from `--config` or `--profile` | `--profile prod` reads `config-prod.yaml` |
 | 3 | Environment variables | `CONDUCTOR_SERVER_URL` |
 | 4 | The default config file | `~/.conductor-cli/config.yaml` |
-| 5 | Built-in defaults | `server-type: OSS` |
-
-That source supplies all settings. The CLI does not read the sources below it.
-
-A flag is different. It changes only its own setting.
-
-`--config` and `--profile` do not hold settings. They select the file on line 2.
 
 So exporting `CONDUCTOR_SERVER_URL` switches the whole configuration onto the environment — an
 auth token sitting in `config.yaml` is not used, and `config show` says so:

--- a/README.md
+++ b/README.md
@@ -755,22 +755,21 @@ auth-secret   -                           default
 auth-token    ****                        config.yaml
 ```
 
-Rank 1 wins over rank 2, rank 2 over rank 3, and so on.
+The CLI uses the first source in this list:
 
-| Rank | Source | Example |
-|------|--------|---------|
-| 1 | Command-line value flags | `--server`, `--auth-token` |
-| 2 | File chosen by `--config` or `--profile` | `--profile prod` reads `config-prod.yaml` |
+| Order | Source | Example |
+|-------|--------|---------|
+| 1 | Flags | `--server`, `--auth-token` |
+| 2 | The file from `--config` or `--profile` | `--profile prod` reads `config-prod.yaml` |
 | 3 | Environment variables | `CONDUCTOR_SERVER_URL` |
-| 4 | Default config file | `~/.conductor-cli/config.yaml` |
+| 4 | The default config file | `~/.conductor-cli/config.yaml` |
 | 5 | Built-in defaults | `server-type: OSS` |
 
-Ranks 2-4 are winner-takes-all: only the highest one present is used, and it supplies *every*
-setting. The ranks below it are not read. Rank 1 is different — it applies per setting, so
-`--server` overrides only the server URL.
+That source supplies all settings. The CLI does not read the sources below it.
 
-`--config` and `--profile` are not rank 1. They carry no settings; they only choose the file in
-rank 2.
+A flag is different. It changes only its own setting.
+
+`--config` and `--profile` do not hold settings. They select the file on line 2.
 
 So exporting `CONDUCTOR_SERVER_URL` switches the whole configuration onto the environment — an
 auth token sitting in `config.yaml` is not used, and `config show` says so:

--- a/README.md
+++ b/README.md
@@ -755,26 +755,22 @@ auth-secret   -                           default
 auth-token    ****                        config.yaml
 ```
 
-There are two kinds of flag. *Value* flags carry a setting: `--server`, `--server-type`,
-`--auth-key`, `--auth-secret`, `--auth-token`. *Selector* flags carry no setting and only choose
-which file to read: `--config <path>`, `--profile <name>`.
+Rank 1 wins over rank 2, rank 2 over rank 3, and so on.
 
-Precedence, highest first:
+| Rank | Source | Example |
+|------|--------|---------|
+| 1 | Command-line value flags | `--server`, `--auth-token` |
+| 2 | File chosen by `--config` or `--profile` | `--profile prod` reads `config-prod.yaml` |
+| 3 | Environment variables | `CONDUCTOR_SERVER_URL` |
+| 4 | Default config file | `~/.conductor-cli/config.yaml` |
+| 5 | Built-in defaults | `server-type: OSS` |
 
-1. Value flags — applied per setting
-2. The file named by `--config` or `--profile`
-3. Environment variables (`CONDUCTOR_SERVER_URL`, `CONDUCTOR_AUTH_TOKEN`, ...)
-4. `~/.conductor-cli/config.yaml`
-5. Built-in defaults
+Ranks 2-4 are winner-takes-all: only the highest one present is used, and it supplies *every*
+setting. The ranks below it are not read. Rank 1 is different — it applies per setting, so
+`--server` overrides only the server URL.
 
-Levels 2-4 are winner-takes-all: the highest one present supplies *every* setting, and the levels
-below it are not consulted at all. They never merge. Only value flags layer on top, per setting.
-
-| Condition | Source |
-|-----------|--------|
-| `--config <path>` or `--profile <name>` given | That file. Environment variables are ignored. |
-| Any `CONDUCTOR_*` setting variable is set | The environment. `config.yaml` is **not read**. |
-| Neither | `~/.conductor-cli/config.yaml` |
+`--config` and `--profile` are not rank 1. They carry no settings; they only choose the file in
+rank 2.
 
 So exporting `CONDUCTOR_SERVER_URL` switches the whole configuration onto the environment — an
 auth token sitting in `config.yaml` is not used, and `config show` says so:

--- a/README.md
+++ b/README.md
@@ -745,20 +745,39 @@ conductor config show
 
 ```
 Profile: default
-File:    /Users/you/.conductor-cli/config.yaml
+Source:  /Users/you/.conductor-cli/config.yaml
+
+KEY           VALUE                       SOURCE
+server        http://localhost:8080/api   config.yaml
+server-type   OSS                         config.yaml
+auth-key      -                           default
+auth-secret   -                           default
+auth-token    ****                        config.yaml
+```
+
+Configuration comes from exactly one source, never a mix of two. Command-line flags override
+individual settings; below them the CLI picks a single source:
+
+| Condition | Source |
+|-----------|--------|
+| `--config <path>` or `--profile <name>` given | That file. Environment variables are ignored. |
+| Any `CONDUCTOR_*` setting variable is set | The environment. `config.yaml` is **not read**. |
+| Neither | `~/.conductor-cli/config.yaml` |
+
+So exporting `CONDUCTOR_SERVER_URL` switches the whole configuration onto the environment — an
+auth token sitting in `config.yaml` is not used, and `config show` says so:
+
+```
+Profile: default
+Source:  environment variables (config file not read)
 
 KEY           VALUE                      SOURCE
 server        http://from-env:9999/api   env CONDUCTOR_SERVER_URL
-server-type   OSS                        config.yaml
-auth-key      -                          default
-auth-secret   -                          default
-auth-token    ****                       config.yaml
+server-type   OSS                        default
+auth-token    -                          default
 ```
 
-Environment variables and the default config merge key by key: the environment wins for the keys
-it sets, and the config file supplies the rest. Selecting a named profile with `--profile` turns
-the environment off, so the profile wins. Secrets are masked unless you pass `--show-secrets`;
-`--json` prints the same data for scripts.
+Secrets are masked unless you pass `--show-secrets`; `--json` prints the same data for scripts.
 
 **Deleting Profiles:**
 

--- a/README.md
+++ b/README.md
@@ -833,12 +833,22 @@ export CONDUCTOR_SERVER_URL=http://localhost:8080/api
 export CONDUCTOR_AUTH_KEY=your-api-key
 export CONDUCTOR_AUTH_SECRET=your-api-secret
 
-# Server type (OSS or Enterprise, defaults to Enterprise)
+# Server type (OSS or Enterprise, defaults to OSS)
 export CONDUCTOR_SERVER_TYPE=OSS
 
 # Profile selection
 export CONDUCTOR_PROFILE=production
 ```
+
+If you set any of `CONDUCTOR_SERVER_URL`, `CONDUCTOR_SERVER_TYPE`, `CONDUCTOR_AUTH_KEY`,
+`CONDUCTOR_AUTH_SECRET` or `CONDUCTOR_AUTH_TOKEN`, the CLI takes every setting from the
+environment and does not read `~/.conductor-cli/config.yaml`. Set all the values you need, or use
+`--profile` to read a file instead. See [Configuration Precedence](#configuration-precedence).
+
+`CONDUCTOR_PROFILE` is different. It selects which file to read, so it does not switch the CLI to
+the environment.
+
+Run `conductor config show` to see the active source and the origin of each value.
 
 #### Disabling Colored Output
 

--- a/cmd/cached_token_manager.go
+++ b/cmd/cached_token_manager.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"path/filepath"
 	"sync"
 	"time"
 
+	"github.com/conductor-oss/conductor-cli/internal/cliconfig"
 	"github.com/conductor-sdk/conductor-go/sdk/authentication"
 	"github.com/conductor-sdk/conductor-go/sdk/settings"
 	log "github.com/sirupsen/logrus"
@@ -193,19 +193,11 @@ func getCurrentTimeUnix() int64 {
 }
 
 // getConfigPath returns the path to the config file for the given profile.
-// Profile name is required — returns an error if empty.
+// An empty name, like "default", resolves to the default config.yaml.
 func getConfigPath(profileName string) (string, error) {
-	if profileName == "" {
-		return "", fmt.Errorf("profile name is required for config path resolution")
-	}
-
-	home, err := os.UserHomeDir()
+	configDir, err := cliconfig.Dir()
 	if err != nil {
 		return "", err
 	}
-
-	configDir := filepath.Join(home, ".conductor-cli")
-	configFileName := fmt.Sprintf("config-%s.yaml", profileName)
-
-	return filepath.Join(configDir, configFileName), nil
+	return cliconfig.Resolve(configDir, profileName), nil
 }

--- a/cmd/cached_token_manager.go
+++ b/cmd/cached_token_manager.go
@@ -205,12 +205,23 @@ func getConfigPath(profileName string) (string, error) {
 // tokenCachePath returns the file a refreshed token should be cached in, or ""
 // to disable caching.
 //
-// Caching is disabled when the default config file does not exist. Creating it
-// would plant a config.yaml on someone who deliberately runs from environment
-// variables, and that file would then supply every setting on any later run
-// where the environment is unset. A named profile always has a file already —
-// initConfig exits if it does not — so it is always cached to.
-func tokenCachePath(profileName string) (string, error) {
+// Caching is disabled in two cases:
+//
+// envActive — the environment supplied this run's credentials, so no file backs
+// it. Writing the token into a config file would store it against whatever
+// identity that file holds: a later run with the environment unset would read
+// the file's key and secret alongside a cached token minted from different
+// credentials, and authenticate as the wrong identity until it expired.
+//
+// The default config file does not exist — creating it would leave a
+// config.yaml on someone who runs from environment variables, and that file
+// would then supply every setting on any later run where the environment is
+// unset. A named profile always has a file already, because initConfig exits
+// when it does not.
+func tokenCachePath(profileName string, envActive bool) (string, error) {
+	if envActive {
+		return "", nil
+	}
 	path, err := getConfigPath(profileName)
 	if err != nil {
 		return "", err

--- a/cmd/cached_token_manager.go
+++ b/cmd/cached_token_manager.go
@@ -201,3 +201,24 @@ func getConfigPath(profileName string) (string, error) {
 	}
 	return cliconfig.Resolve(configDir, profileName), nil
 }
+
+// tokenCachePath returns the file a refreshed token should be cached in, or ""
+// to disable caching.
+//
+// Caching is disabled when the default config file does not exist. Creating it
+// would plant a config.yaml on someone who deliberately runs from environment
+// variables, and that file would then supply every setting on any later run
+// where the environment is unset. A named profile always has a file already —
+// initConfig exits if it does not — so it is always cached to.
+func tokenCachePath(profileName string) (string, error) {
+	path, err := getConfigPath(profileName)
+	if err != nil {
+		return "", err
+	}
+	if cliconfig.IsDefault(profileName) {
+		if _, err := os.Stat(path); err != nil {
+			return "", nil
+		}
+	}
+	return path, nil
+}

--- a/cmd/cached_token_manager.go
+++ b/cmd/cached_token_manager.go
@@ -193,7 +193,7 @@ func getCurrentTimeUnix() int64 {
 }
 
 // getConfigPath returns the path to the config file for the given profile.
-// An empty name, like "default", resolves to the default config.yaml.
+// An empty name and "default" both resolve to config.yaml.
 func getConfigPath(profileName string) (string, error) {
 	configDir, err := cliconfig.Dir()
 	if err != nil {

--- a/cmd/cached_token_manager_test.go
+++ b/cmd/cached_token_manager_test.go
@@ -49,8 +49,9 @@ func TestGetConfigPath(t *testing.T) {
 		wantSuffix  string
 	}{
 		{
-			// Cached tokens have somewhere to go now that config.yaml is
-			// writable (#98).
+			// This used to return an error, so with no profile selected the
+			// cached token had no file to be written to and was refetched on
+			// every run (#98).
 			name:        "empty profile is the default config",
 			profileName: "",
 			wantSuffix:  filepath.Join(".conductor-cli", "config.yaml"),

--- a/cmd/cached_token_manager_test.go
+++ b/cmd/cached_token_manager_test.go
@@ -86,6 +86,87 @@ func TestGetConfigPath(t *testing.T) {
 	}
 }
 
+func TestTokenCachePath(t *testing.T) {
+	// Each case runs against its own HOME so the developer's real
+	// ~/.conductor-cli is never read or written.
+	newHome := func(t *testing.T, withDefaultConfig bool) string {
+		t.Helper()
+		home := t.TempDir()
+		dir := filepath.Join(home, ".conductor-cli")
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if withDefaultConfig {
+			if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("server: http://x\n"), 0600); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return home
+	}
+
+	t.Run("default config absent disables caching", func(t *testing.T) {
+		// The guard that matters: someone running from environment variables
+		// must not have a config.yaml created for them, because it would then
+		// supply every setting on a later run with the environment unset.
+		t.Setenv("HOME", newHome(t, false))
+
+		got, err := tokenCachePath("")
+		if err != nil {
+			t.Fatalf("tokenCachePath(\"\") error: %v", err)
+		}
+		if got != "" {
+			t.Errorf("tokenCachePath(\"\") = %q, want empty so no file is created", got)
+		}
+	})
+
+	t.Run("default config present is cached to", func(t *testing.T) {
+		home := newHome(t, true)
+		t.Setenv("HOME", home)
+
+		got, err := tokenCachePath("")
+		if err != nil {
+			t.Fatalf("tokenCachePath(\"\") error: %v", err)
+		}
+		want := filepath.Join(home, ".conductor-cli", "config.yaml")
+		if got != want {
+			t.Errorf("tokenCachePath(\"\") = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("default alias behaves like an empty name", func(t *testing.T) {
+		t.Setenv("HOME", newHome(t, false))
+
+		empty, err := tokenCachePath("")
+		if err != nil {
+			t.Fatal(err)
+		}
+		alias, err := tokenCachePath("default")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if empty != alias {
+			t.Errorf("tokenCachePath(\"default\") = %q, want %q", alias, empty)
+		}
+	})
+
+	t.Run("named profile is cached to even when its file is missing", func(t *testing.T) {
+		// initConfig exits when a named profile's file is absent, so reaching
+		// here means it exists. The guard must not extend to named profiles, or
+		// key/secret users would silently lose token caching.
+		home := newHome(t, false)
+		t.Setenv("HOME", home)
+
+		got, err := tokenCachePath("production")
+		if err != nil {
+			t.Fatalf("tokenCachePath(production) error: %v", err)
+		}
+		want := filepath.Join(home, ".conductor-cli", "config-production.yaml")
+		if got != want {
+			t.Errorf("tokenCachePath(production) = %q, want %q", got, want)
+		}
+	})
+}
+
 func TestReadConfigFile(t *testing.T) {
 	t.Run("file does not exist returns empty map", func(t *testing.T) {
 		mgr := &CachedTokenManager{

--- a/cmd/cached_token_manager_test.go
+++ b/cmd/cached_token_manager_test.go
@@ -49,8 +49,8 @@ func TestGetConfigPath(t *testing.T) {
 		wantSuffix  string
 	}{
 		{
-			// A cached token for the default config has somewhere to go now
-			// that config.yaml is writable (#98).
+			// Cached tokens have somewhere to go now that config.yaml is
+			// writable (#98).
 			name:        "empty profile is the default config",
 			profileName: "",
 			wantSuffix:  filepath.Join(".conductor-cli", "config.yaml"),

--- a/cmd/cached_token_manager_test.go
+++ b/cmd/cached_token_manager_test.go
@@ -49,9 +49,16 @@ func TestGetConfigPath(t *testing.T) {
 		wantSuffix  string
 	}{
 		{
-			name:        "empty profile returns error",
+			// A cached token for the default config has somewhere to go now
+			// that config.yaml is writable (#98).
+			name:        "empty profile is the default config",
 			profileName: "",
-			wantSuffix:  "",
+			wantSuffix:  filepath.Join(".conductor-cli", "config.yaml"),
+		},
+		{
+			name:        "default is an alias for the same file",
+			profileName: "default",
+			wantSuffix:  filepath.Join(".conductor-cli", "config.yaml"),
 		},
 		{
 			name:        "named profile",
@@ -68,12 +75,6 @@ func TestGetConfigPath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := getConfigPath(tt.profileName)
-			if tt.profileName == "" {
-				if err == nil {
-					t.Fatalf("getConfigPath(%q) expected error, got path %q", tt.profileName, got)
-				}
-				return
-			}
 			if err != nil {
 				t.Fatalf("getConfigPath(%q) error: %v", tt.profileName, err)
 			}

--- a/cmd/cached_token_manager_test.go
+++ b/cmd/cached_token_manager_test.go
@@ -104,13 +104,31 @@ func TestTokenCachePath(t *testing.T) {
 		return home
 	}
 
+	t.Run("environment as the active source disables caching", func(t *testing.T) {
+		// The config file exists, but the environment supplied this run's
+		// credentials. Writing the token into that file would store it against
+		// the identity the file holds: a later run with the environment unset
+		// would pair the file's key and secret with a token minted from
+		// different credentials.
+		home := newHome(t, true)
+		t.Setenv("HOME", home)
+
+		got, err := tokenCachePath("", true)
+		if err != nil {
+			t.Fatalf("tokenCachePath with envActive error: %v", err)
+		}
+		if got != "" {
+			t.Errorf("tokenCachePath with envActive = %q, want empty so the file is not written", got)
+		}
+	})
+
 	t.Run("default config absent disables caching", func(t *testing.T) {
-		// The guard that matters: someone running from environment variables
-		// must not have a config.yaml created for them, because it would then
-		// supply every setting on a later run with the environment unset.
+		// Creating the file would leave a config.yaml on someone who runs from
+		// environment variables, and it would then supply every setting on a
+		// later run with the environment unset.
 		t.Setenv("HOME", newHome(t, false))
 
-		got, err := tokenCachePath("")
+		got, err := tokenCachePath("", false)
 		if err != nil {
 			t.Fatalf("tokenCachePath(\"\") error: %v", err)
 		}
@@ -123,7 +141,7 @@ func TestTokenCachePath(t *testing.T) {
 		home := newHome(t, true)
 		t.Setenv("HOME", home)
 
-		got, err := tokenCachePath("")
+		got, err := tokenCachePath("", false)
 		if err != nil {
 			t.Fatalf("tokenCachePath(\"\") error: %v", err)
 		}
@@ -136,11 +154,11 @@ func TestTokenCachePath(t *testing.T) {
 	t.Run("default alias behaves like an empty name", func(t *testing.T) {
 		t.Setenv("HOME", newHome(t, false))
 
-		empty, err := tokenCachePath("")
+		empty, err := tokenCachePath("", false)
 		if err != nil {
 			t.Fatal(err)
 		}
-		alias, err := tokenCachePath("default")
+		alias, err := tokenCachePath("default", false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -156,7 +174,7 @@ func TestTokenCachePath(t *testing.T) {
 		home := newHome(t, false)
 		t.Setenv("HOME", home)
 
-		got, err := tokenCachePath("production")
+		got, err := tokenCachePath("production", false)
 		if err != nil {
 			t.Fatalf("tokenCachePath(production) error: %v", err)
 		}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -227,7 +227,7 @@ Examples:
 }
 
 // interactiveSaveConfig prompts for settings and writes profileName's config
-// file, returning the path. An empty name, like "default", writes config.yaml.
+// file, returning the path. An empty name and "default" both write config.yaml.
 func interactiveSaveConfig(profileName string) (string, error) {
 	configDir, err := cliconfig.Dir()
 	if err != nil {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -452,7 +452,7 @@ Command-line flags override individual settings. Everything else comes from a
 single source, never a mix of two:
 
   --config <path> or --profile <name>   that file; environment ignored
-  any CONDUCTOR_* variable set          the environment; config file not read
+  any CONDUCTOR_* variable set          the environment; the config file is not read
   otherwise                             ~/.conductor-cli/config.yaml
 
 Secrets are masked unless --show-secrets is passed.
@@ -507,7 +507,7 @@ Examples:
 		// selects a file the CLI did not read.
 		switch {
 		case res.EnvBound:
-			fmt.Printf("Source: environment variables (config file not read)\n")
+			fmt.Printf("Source: environment variables\n")
 		case res.File != "":
 			fmt.Printf("Source: %s\n", res.File)
 		default:

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -67,8 +67,7 @@ Examples:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		profileName := profile
 
-		// Only prompt when --profile was not given; an empty answer means the
-		// default configuration rather than an error (#98).
+		// An empty answer means the default config rather than an error (#98).
 		if profileName == "" && !cmd.Flags().Changed("profile") {
 			reader := bufio.NewReader(os.Stdin)
 			fmt.Fprintf(os.Stdout, "Profile name (empty for default): ")
@@ -138,9 +137,8 @@ Examples:
 			if strings.HasPrefix(name, "config-") && strings.HasSuffix(name, ".yaml") {
 				profileName := strings.TrimPrefix(name, "config-")
 				profileName = strings.TrimSuffix(profileName, ".yaml")
-				// "default" refers to config.yaml, so a config-default.yaml is
-				// unreachable. Listing it would print "default" twice for two
-				// different files; warnStrayDefaultFile explains it instead.
+				// Unreachable: "default" refers to config.yaml. Listing it would
+				// print "default" twice. warnStrayDefaultFile explains it.
 				if cliconfig.IsDefault(profileName) {
 					continue
 				}
@@ -189,8 +187,8 @@ Examples:
 			profileName = profile
 		}
 
-		// Deleting always names its target: an empty name would silently mean
-		// the default config, which is too easy to trigger by accident.
+		// Deleting always names its target; an empty name is too easy to hit by
+		// accident.
 		if profileName == "" {
 			return fmt.Errorf("profile name is required (use positional argument or --profile flag, or 'default' for the default config)")
 		}
@@ -228,9 +226,8 @@ Examples:
 	SilenceUsage: true,
 }
 
-// interactiveSaveConfig prompts for settings and writes them to profileName's
-// config file, returning the path written. An empty name (or "default") writes
-// the default config.yaml.
+// interactiveSaveConfig prompts for settings and writes profileName's config
+// file, returning the path. An empty name, like "default", writes config.yaml.
 func interactiveSaveConfig(profileName string) (string, error) {
 	configDir, err := cliconfig.Dir()
 	if err != nil {
@@ -436,10 +433,8 @@ func ReadLineRaw(limit int) (string, error) {
 	}
 }
 
-// warnStrayDefaultFile tells the user about a config-default.yaml, which no
-// longer loads now that "default" refers to config.yaml. Earlier builds created
-// such files, and silently ignoring one leaves the user believing settings are
-// active when they are not.
+// warnStrayDefaultFile reports a config-default.yaml, which no longer loads.
+// Ignoring one silently leaves the user believing its settings are active.
 func warnStrayDefaultFile(configDir string) {
 	if stray := cliconfig.StrayDefaultFile(configDir); stray != "" {
 		fmt.Fprintf(os.Stderr,
@@ -514,8 +509,8 @@ Examples:
 		}
 		switch {
 		case res.EnvBound:
-			// Say plainly that the file was skipped; an unexplained "(none)"
-			// next to an existing config.yaml reads like a bug.
+			// Say the file was skipped; a bare "(none)" beside an existing
+			// config.yaml reads like a bug.
 			fmt.Printf("Source:  environment variables (config file not read)\n")
 		case res.File != "":
 			fmt.Printf("Source:  %s\n", res.File)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -502,20 +502,16 @@ Examples:
 			return nil
 		}
 
-		if res.IsDefaultProfile() {
-			fmt.Printf("Profile: default\n")
-		} else {
-			fmt.Printf("Profile: %s\n", res.Profile)
-		}
+		// Only the active source is named. Printing a profile alongside
+		// "environment variables" contradicts itself, because the profile
+		// selects a file the CLI did not read.
 		switch {
 		case res.EnvBound:
-			// Say the file was skipped; a bare "(none)" beside an existing
-			// config.yaml reads like a bug.
-			fmt.Printf("Source:  environment variables (config file not read)\n")
+			fmt.Printf("Source: environment variables (config file not read)\n")
 		case res.File != "":
-			fmt.Printf("Source:  %s\n", res.File)
+			fmt.Printf("Source: %s\n", res.File)
 		default:
-			fmt.Printf("Source:  none (built-in defaults)\n")
+			fmt.Printf("Source: built-in defaults\n")
 		}
 		fmt.Println()
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -16,16 +16,25 @@ package cmd
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"golang.org/x/term"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
+	"text/tabwriter"
 
+	"github.com/conductor-oss/conductor-cli/internal/cliconfig"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
+)
+
+// Flags for `config show`.
+var (
+	configShowJSON    bool
+	configShowSecrets bool
 )
 
 var configCmd = &cobra.Command{
@@ -37,39 +46,42 @@ var configCmd = &cobra.Command{
 var configSaveCmd = &cobra.Command{
 	Use:   "save",
 	Short: "Save configuration to file (interactive)",
-	Long: `Interactively configure and save server and authentication settings to a named profile.
+	Long: `Interactively configure and save server and authentication settings.
 
-The configuration will be saved to ~/.conductor-cli/config-<profile>.yaml.
-A profile name is required — you will be prompted if --profile is not specified.
+Named profiles are saved to ~/.conductor-cli/config-<profile>.yaml. The default
+configuration is saved to ~/.conductor-cli/config.yaml — leave the profile name
+empty at the prompt, or pass --profile default.
 
 If a configuration already exists, you can press Enter to keep existing values.
 
 Examples:
-  # Interactively save (will prompt for profile name)
+  # Save the default configuration (press Enter at the profile prompt)
   conductor config save
 
-  # Save to a named profile directly
+  # Same thing, without the prompt
+  conductor config save --profile default
+
+  # Save to a named profile
   conductor config save --profile production
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		profileName := profile
 
-		if profileName == "" {
+		// Only prompt when --profile was not given; an empty answer means the
+		// default configuration rather than an error (#98).
+		if profileName == "" && !cmd.Flags().Changed("profile") {
 			reader := bufio.NewReader(os.Stdin)
-			fmt.Fprintf(os.Stdout, "Profile name: ")
+			fmt.Fprintf(os.Stdout, "Profile name (empty for default): ")
 			input, _ := reader.ReadString('\n')
 			profileName = strings.TrimSpace(input)
-			if profileName == "" {
-				return fmt.Errorf("profile name is required")
-			}
 		}
 
-		if err := interactiveSaveConfig(profileName); err != nil {
+		configPath, err := interactiveSaveConfig(profileName)
+		if err != nil {
 			return fmt.Errorf("failed to save config: %w", err)
 		}
 
-		configFileName := fmt.Sprintf("config-%s.yaml", profileName)
-		fmt.Fprintf(os.Stdout, "✓ Configuration saved to ~/.conductor-cli/%s\n", configFileName)
+		fmt.Fprintf(os.Stdout, "✓ Configuration saved to %s\n", configPath)
 		return nil
 	},
 	SilenceUsage: true,
@@ -80,25 +92,26 @@ var configListCmd = &cobra.Command{
 	Short: "List all configuration profiles",
 	Long: `List all configuration profiles in ~/.conductor-cli directory.
 
-Shows all named profiles (config-<profile>.yaml).
+Shows the default configuration (config.yaml) as "default", plus every named
+profile (config-<profile>.yaml).
 
 Examples:
   # List all config profiles
   conductor config list
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		home, err := os.UserHomeDir()
+		configDir, err := cliconfig.Dir()
 		if err != nil {
 			return err
 		}
-
-		configDir := filepath.Join(home, ".conductor-cli")
 
 		// Check if config directory exists
 		if _, err := os.Stat(configDir); os.IsNotExist(err) {
 			fmt.Println("No configuration files found")
 			return nil
 		}
+
+		warnStrayDefaultFile(configDir)
 
 		// Read all files in config directory
 		files, err := os.ReadDir(configDir)
@@ -125,6 +138,12 @@ Examples:
 			if strings.HasPrefix(name, "config-") && strings.HasSuffix(name, ".yaml") {
 				profileName := strings.TrimPrefix(name, "config-")
 				profileName = strings.TrimSuffix(profileName, ".yaml")
+				// "default" refers to config.yaml, so a config-default.yaml is
+				// unreachable. Listing it would print "default" twice for two
+				// different files; warnStrayDefaultFile explains it instead.
+				if cliconfig.IsDefault(profileName) {
+					continue
+				}
 				fmt.Println(profileName)
 				hasConfigs = true
 			}
@@ -157,12 +176,10 @@ Examples:
   conductor config delete production -y
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		home, err := os.UserHomeDir()
+		configDir, err := cliconfig.Dir()
 		if err != nil {
 			return err
 		}
-
-		configDir := filepath.Join(home, ".conductor-cli")
 
 		// Get profile name from either positional arg or --profile flag
 		var profileName string
@@ -172,12 +189,13 @@ Examples:
 			profileName = profile
 		}
 
+		// Deleting always names its target: an empty name would silently mean
+		// the default config, which is too easy to trigger by accident.
 		if profileName == "" {
-			return fmt.Errorf("profile name is required (use positional argument or --profile flag)")
+			return fmt.Errorf("profile name is required (use positional argument or --profile flag, or 'default' for the default config)")
 		}
 
-		configFileName := fmt.Sprintf("config-%s.yaml", profileName)
-		configPath := filepath.Join(configDir, configFileName)
+		configPath := cliconfig.Resolve(configDir, profileName)
 
 		// Check if config file exists
 		if _, err := os.Stat(configPath); os.IsNotExist(err) {
@@ -210,25 +228,21 @@ Examples:
 	SilenceUsage: true,
 }
 
-func interactiveSaveConfig(profileName string) error {
-	if profileName == "" {
-		return fmt.Errorf("profile name is required")
-	}
-
-	home, err := os.UserHomeDir()
+// interactiveSaveConfig prompts for settings and writes them to profileName's
+// config file, returning the path written. An empty name (or "default") writes
+// the default config.yaml.
+func interactiveSaveConfig(profileName string) (string, error) {
+	configDir, err := cliconfig.Dir()
 	if err != nil {
-		return err
+		return "", err
 	}
-
-	configDir := filepath.Join(home, ".conductor-cli")
 
 	// Create config directory if it doesn't exist
 	if err := os.MkdirAll(configDir, 0755); err != nil {
-		return err
+		return "", err
 	}
 
-	configFileName := fmt.Sprintf("config-%s.yaml", profileName)
-	configPath := filepath.Join(configDir, configFileName)
+	configPath := cliconfig.Resolve(configDir, profileName)
 
 	// Load existing config if it exists
 	existingConfig := make(map[string]string)
@@ -366,10 +380,13 @@ func interactiveSaveConfig(profileName string) error {
 
 	data, err := yaml.Marshal(configData)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	return os.WriteFile(configPath, data, 0600)
+	if err := os.WriteFile(configPath, data, 0600); err != nil {
+		return "", err
+	}
+	return configPath, nil
 }
 
 var ErrTooLong = errors.New("input exceeds limit")
@@ -419,9 +436,108 @@ func ReadLineRaw(limit int) (string, error) {
 	}
 }
 
+// warnStrayDefaultFile tells the user about a config-default.yaml, which no
+// longer loads now that "default" refers to config.yaml. Earlier builds created
+// such files, and silently ignoring one leaves the user believing settings are
+// active when they are not.
+func warnStrayDefaultFile(configDir string) {
+	if stray := cliconfig.StrayDefaultFile(configDir); stray != "" {
+		fmt.Fprintf(os.Stderr,
+			"Warning: %s is not used; \"default\" refers to config.yaml. Rename or delete it to silence this warning.\n",
+			stray)
+	}
+}
+
+var configShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Show the effective configuration and where each value came from",
+	Long: `Show the configuration the CLI actually resolved, with the origin of each value.
+
+Values come from, in order of precedence: command-line flags, environment
+variables, the config file, then built-in defaults. Environment variables are
+only consulted for the default configuration — selecting a named profile with
+--profile makes that profile win over the environment.
+
+Secrets are masked unless --show-secrets is passed.
+
+Examples:
+  # Show the effective configuration
+  conductor config show
+
+  # Show what a named profile resolves to
+  conductor --profile production config show
+
+  # Machine-readable output
+  conductor config show --json
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if configDir, err := cliconfig.Dir(); err == nil {
+			warnStrayDefaultFile(configDir)
+		}
+
+		res := activeResolution(cmd)
+
+		type entry struct {
+			Key    string `json:"key"`
+			Value  string `json:"value"`
+			Source string `json:"source"`
+		}
+		entries := make([]entry, 0, len(cliconfig.Keys))
+		for _, key := range cliconfig.Keys {
+			value := viper.GetString(key)
+			if !configShowSecrets {
+				value = cliconfig.Mask(key, value)
+			}
+			entries = append(entries, entry{Key: key, Value: value, Source: res.SourceOf(key).ShortString()})
+		}
+
+		if configShowJSON {
+			payload := struct {
+				Profile string  `json:"profile"`
+				File    string  `json:"file"`
+				Values  []entry `json:"values"`
+			}{Profile: res.Profile, File: res.File, Values: entries}
+			out, err := json.MarshalIndent(payload, "", "  ")
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(out))
+			return nil
+		}
+
+		if res.IsDefaultProfile() {
+			fmt.Printf("Profile: default\n")
+		} else {
+			fmt.Printf("Profile: %s\n", res.Profile)
+		}
+		if res.File == "" {
+			fmt.Printf("File:    (none)\n")
+		} else {
+			fmt.Printf("File:    %s\n", res.File)
+		}
+		fmt.Println()
+
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		fmt.Fprintln(w, "KEY\tVALUE\tSOURCE")
+		for _, e := range entries {
+			value := e.Value
+			if value == "" {
+				value = "-"
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\n", e.Key, value, e.Source)
+		}
+		return w.Flush()
+	},
+	SilenceUsage: true,
+}
+
 func init() {
 	rootCmd.AddCommand(configCmd)
 	configCmd.AddCommand(configSaveCmd)
 	configCmd.AddCommand(configListCmd)
 	configCmd.AddCommand(configDeleteCmd)
+	configCmd.AddCommand(configShowCmd)
+
+	configShowCmd.Flags().BoolVar(&configShowJSON, "json", false, "Output as JSON")
+	configShowCmd.Flags().BoolVar(&configShowSecrets, "show-secrets", false, "Display secret values instead of masking them")
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -453,10 +453,12 @@ var configShowCmd = &cobra.Command{
 	Short: "Show the effective configuration and where each value came from",
 	Long: `Show the configuration the CLI actually resolved, with the origin of each value.
 
-Values come from, in order of precedence: command-line flags, environment
-variables, the config file, then built-in defaults. Environment variables are
-only consulted for the default configuration — selecting a named profile with
---profile makes that profile win over the environment.
+Command-line flags override individual settings. Everything else comes from a
+single source, never a mix of two:
+
+  --config <path> or --profile <name>   that file; environment ignored
+  any CONDUCTOR_* variable set          the environment; config file not read
+  otherwise                             ~/.conductor-cli/config.yaml
 
 Secrets are masked unless --show-secrets is passed.
 
@@ -510,10 +512,15 @@ Examples:
 		} else {
 			fmt.Printf("Profile: %s\n", res.Profile)
 		}
-		if res.File == "" {
-			fmt.Printf("File:    (none)\n")
-		} else {
-			fmt.Printf("File:    %s\n", res.File)
+		switch {
+		case res.EnvBound:
+			// Say plainly that the file was skipped; an unexplained "(none)"
+			// next to an existing config.yaml reads like a bug.
+			fmt.Printf("Source:  environment variables (config file not read)\n")
+		case res.File != "":
+			fmt.Printf("Source:  %s\n", res.File)
+		default:
+			fmt.Printf("Source:  none (built-in defaults)\n")
 		}
 		fmt.Println()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -179,8 +179,8 @@ var rootCmd = &cobra.Command{
 			cachedToken := viper.GetString("cached-token")
 			cachedExpiry := viper.GetInt64("cached-token-expiry")
 
-			// initConfig already resolved the profile; reuse it.
-			configPath, err := tokenCachePath(activeProfile)
+			// initConfig already resolved the profile and the active source.
+			configPath, err := tokenCachePath(activeProfile, envIsActiveSource)
 			if err != nil {
 				return fmt.Errorf("failed to get config path: %w", err)
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,10 +19,10 @@ import (
 	"io"
 	stdlog "log"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/conductor-oss/conductor-cli/internal"
+	"github.com/conductor-oss/conductor-cli/internal/cliconfig"
 	"github.com/conductor-oss/conductor-cli/internal/transport"
 	"github.com/conductor-oss/conductor-cli/internal/updater"
 	"github.com/conductor-sdk/conductor-go/sdk/client"
@@ -181,18 +181,21 @@ var rootCmd = &cobra.Command{
 			cachedToken := viper.GetString("cached-token")
 			cachedExpiry := viper.GetInt64("cached-token-expiry")
 
-			// Determine config path for saving cached token
-			activeProfile := profile
-			if activeProfile == "" {
-				activeProfile = os.Getenv("CONDUCTOR_PROFILE")
+			// Determine config path for saving cached token. initConfig already
+			// resolved the profile, so reuse it rather than recomputing.
+			configPath, err := getConfigPath(activeProfile)
+			if err != nil {
+				return fmt.Errorf("failed to get config path: %w", err)
 			}
 
-			configPath := ""
-			if activeProfile != "" {
-				var err error
-				configPath, err = getConfigPath(activeProfile)
-				if err != nil {
-					return fmt.Errorf("failed to get config path: %w", err)
+			// Caching into the default config is only safe when that file
+			// already exists. Creating it here would plant a config.yaml on
+			// users who deliberately run on environment variables alone, and
+			// that file would then start winning over their environment for
+			// every key it holds.
+			if cliconfig.IsDefault(activeProfile) {
+				if _, statErr := os.Stat(configPath); statErr != nil {
+					configPath = ""
 				}
 			}
 
@@ -255,61 +258,69 @@ func Execute(ctx context.Context) {
 	}
 }
 
+// activeProfile is the profile initConfig settled on: the --profile flag, else
+// CONDUCTOR_PROFILE, else empty for the default configuration. `config show`
+// reports against it.
+var activeProfile string
+
+// loadedConfigFile is the config file initConfig actually read, or "" when none
+// was found.
+var loadedConfigFile string
+
+// effectiveProfile resolves which profile the CLI should use. The --profile flag
+// takes precedence over the CONDUCTOR_PROFILE environment variable.
+func effectiveProfile() string {
+	if profile != "" {
+		return profile
+	}
+	return os.Getenv("CONDUCTOR_PROFILE")
+}
+
+// isSavingConfig reports whether this invocation is `config save`, which is
+// allowed to name a profile whose file does not exist yet.
+func isSavingConfig() bool {
+	for i, arg := range os.Args {
+		if arg == "config" && i+1 < len(os.Args) && os.Args[i+1] == "save" {
+			return true
+		}
+	}
+	return false
+}
+
 func initConfig() {
+	activeProfile = effectiveProfile()
+
 	if cfgFile != "" {
 		viper.SetConfigFile(cfgFile)
 	} else {
-		home, err := os.UserHomeDir()
+		configDir, err := cliconfig.Dir()
 		cobra.CheckErr(err)
 
 		// Use config directory structure: ~/.conductor-cli/config.yaml or config-<profile>.yaml
-		configDir := filepath.Join(home, ".conductor-cli")
 		viper.AddConfigPath(configDir)
 		viper.SetConfigType("yaml")
 
-		// Determine which profile to use: --profile flag takes precedence over CONDUCTOR_PROFILE env var
-		activeProfile := profile
-		if activeProfile == "" {
-			activeProfile = os.Getenv("CONDUCTOR_PROFILE")
+		// A named profile must already exist; the default configuration is
+		// optional, since the CLI also runs on flags and environment alone.
+		if !cliconfig.IsDefault(activeProfile) && !isSavingConfig() {
+			configPath := cliconfig.Resolve(configDir, activeProfile)
+			if _, err := os.Stat(configPath); os.IsNotExist(err) {
+				fmt.Fprintf(os.Stderr, "Error: Profile '%s' doesn't exist (expected file: %s)\n", activeProfile, configPath)
+				os.Exit(1)
+			}
 		}
 
-		// Use profile-specific config if profile is set
-		if activeProfile != "" {
-			configName := fmt.Sprintf("config-%s", activeProfile)
-			configPath := filepath.Join(configDir, configName+".yaml")
-
-			// Check if profile config exists (skip check if we're saving a new config)
-			isSavingConfig := false
-			for i, arg := range os.Args {
-				if arg == "config" && i+1 < len(os.Args) && os.Args[i+1] == "save" {
-					isSavingConfig = true
-					break
-				}
-			}
-
-			if !isSavingConfig {
-				if _, err := os.Stat(configPath); os.IsNotExist(err) {
-					fmt.Fprintf(os.Stderr, "Error: Profile '%s' doesn't exist (expected file: %s)\n", activeProfile, configPath)
-					os.Exit(1)
-				}
-			}
-
-			viper.SetConfigName(configName)
-		}
-		// When no profile is active, no config file is loaded.
-		// The CLI relies on environment variables and CLI flags only.
+		// Name the file explicitly, including "config" for the default. viper
+		// would find that name on its own, and relying on that is precisely how
+		// the default config kept loading after `config save` lost the ability
+		// to write it (#98).
+		viper.SetConfigName(cliconfig.FileName(activeProfile))
 	}
 
-	// Only bind environment variables when no profile is active.
-	// When a profile is explicitly selected, the profile config should take
-	// precedence over ambient environment variables. CLI flags (via BindPFlag)
-	// still override everything regardless.
-	activeProfile := profile
-	if activeProfile == "" {
-		activeProfile = os.Getenv("CONDUCTOR_PROFILE")
-	}
-
-	if activeProfile == "" {
+	// Bind environment variables only for the default configuration. Selecting a
+	// named profile is an explicit choice, so it wins over ambient environment;
+	// CLI flags (via BindPFlag) still override everything either way.
+	if cliconfig.IsDefault(activeProfile) {
 		viper.SetEnvPrefix("CONDUCTOR")
 		viper.AutomaticEnv()
 
@@ -320,31 +331,49 @@ func initConfig() {
 		viper.BindEnv("server-type", "CONDUCTOR_SERVER_TYPE")
 	}
 
-	// Determine if env vars are the active config source (no profile selected)
-	usingEnvVars := profile == "" && os.Getenv("CONDUCTOR_PROFILE") == ""
-
-	if viper.GetBool("verbose") && usingEnvVars {
-		for _, ev := range []string{"CONDUCTOR_SERVER_URL", "CONDUCTOR_AUTH_TOKEN", "CONDUCTOR_AUTH_KEY", "CONDUCTOR_AUTH_SECRET", "CONDUCTOR_SERVER_TYPE"} {
-			if v := os.Getenv(ev); v != "" {
-				switch ev {
-				case "CONDUCTOR_AUTH_TOKEN", "CONDUCTOR_AUTH_SECRET":
-					fmt.Fprintf(os.Stdout, "Using env var %s: (set)\n", ev)
-				default:
-					fmt.Fprintf(os.Stdout, "Using env var %s: %s\n", ev, v)
-				}
-			}
-		}
-	}
-
+	// A missing config file is not an error: the CLI also runs on flags and
+	// environment alone. Only a file that was read counts as a source.
 	if err := viper.ReadInConfig(); err == nil {
-		if viper.GetBool("verbose") {
-			// When CONDUCTOR_SERVER_URL env var is active, suppress the config file message
-			// to avoid confusion about which source the server URL came from.
-			if !usingEnvVars || os.Getenv("CONDUCTOR_SERVER_URL") == "" {
-				fmt.Fprintf(os.Stdout, "Using config file: %s\n", viper.ConfigFileUsed())
-			}
-		}
+		loadedConfigFile = viper.ConfigFileUsed()
 	}
+
+	if viper.GetBool("verbose") {
+		reportConfigSources()
+	}
+}
+
+// reportConfigSources prints where each setting came from. It reports the file
+// and the environment together: they merge key by key for the default
+// configuration, so naming only one of them hides the other's contribution.
+func reportConfigSources() {
+	res := cliconfig.NewResolution(activeProfile, loadedConfigFile, rootFlagChanged)
+
+	if res.File != "" {
+		fmt.Fprintf(os.Stdout, "Using config file: %s\n", res.File)
+	}
+	for _, key := range cliconfig.Keys {
+		src := res.SourceOf(key)
+		if src.Kind == cliconfig.SourceDefault {
+			continue
+		}
+		// The full path is already on the "Using config file" line above.
+		fmt.Fprintf(os.Stdout, "Using %s: %s (%s)\n", key, cliconfig.Mask(key, viper.GetString(key)), src.ShortString())
+	}
+}
+
+// rootFlagChanged reports whether the user passed the flag for key.
+func rootFlagChanged(key string) bool {
+	f := rootCmd.PersistentFlags().Lookup(key)
+	return f != nil && f.Changed
+}
+
+// activeResolution describes the configuration state this invocation resolved,
+// including which flags cmd actually saw.
+func activeResolution(cmd *cobra.Command) cliconfig.Resolution {
+	return cliconfig.NewResolution(activeProfile, loadedConfigFile, func(key string) bool {
+		f := cmd.Flags().Lookup(key)
+		return f != nil && f.Changed
+	})
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -287,8 +287,23 @@ func isSavingConfig() bool {
 	return false
 }
 
+// envIsActiveSource is true when the environment supplied this invocation's
+// configuration, meaning no config file was read.
+var envIsActiveSource bool
+
 func initConfig() {
 	activeProfile = effectiveProfile()
+
+	// Naming a file is an explicit choice and wins over the ambient environment:
+	// --config names a path, --profile names one of the CLI's own files.
+	namedFile := cfgFile != "" || !cliconfig.IsDefault(activeProfile)
+
+	// Below flags, exactly one source supplies configuration. Naming a file
+	// selects that file; otherwise setting any CONDUCTOR_* variable selects the
+	// environment wholesale and the default config.yaml is not read. The two
+	// never merge: a value blended from both leaves no answer to "where did this
+	// come from".
+	envIsActiveSource = !namedFile && cliconfig.EnvActive()
 
 	if cfgFile != "" {
 		viper.SetConfigFile(cfgFile)
@@ -317,10 +332,7 @@ func initConfig() {
 		viper.SetConfigName(cliconfig.FileName(activeProfile))
 	}
 
-	// Bind environment variables only for the default configuration. Selecting a
-	// named profile is an explicit choice, so it wins over ambient environment;
-	// CLI flags (via BindPFlag) still override everything either way.
-	if cliconfig.IsDefault(activeProfile) {
+	if envIsActiveSource {
 		viper.SetEnvPrefix("CONDUCTOR")
 		viper.AutomaticEnv()
 
@@ -329,12 +341,12 @@ func initConfig() {
 		viper.BindEnv("auth-secret", "CONDUCTOR_AUTH_SECRET")
 		viper.BindEnv("auth-token", "CONDUCTOR_AUTH_TOKEN")
 		viper.BindEnv("server-type", "CONDUCTOR_SERVER_TYPE")
-	}
-
-	// A missing config file is not an error: the CLI also runs on flags and
-	// environment alone. Only a file that was read counts as a source.
-	if err := viper.ReadInConfig(); err == nil {
-		loadedConfigFile = viper.ConfigFileUsed()
+	} else {
+		// A missing config file is not an error: the CLI also runs on flags
+		// alone. Only a file that was read counts as a source.
+		if err := viper.ReadInConfig(); err == nil {
+			loadedConfigFile = viper.ConfigFileUsed()
+		}
 	}
 
 	if viper.GetBool("verbose") {
@@ -342,13 +354,15 @@ func initConfig() {
 	}
 }
 
-// reportConfigSources prints where each setting came from. It reports the file
-// and the environment together: they merge key by key for the default
-// configuration, so naming only one of them hides the other's contribution.
+// reportConfigSources prints where each setting came from, so that a surprising
+// server URL can be traced without guessing between the environment and a file.
 func reportConfigSources() {
-	res := cliconfig.NewResolution(activeProfile, loadedConfigFile, rootFlagChanged)
+	res := cliconfig.NewResolution(activeProfile, loadedConfigFile, envIsActiveSource, rootFlagChanged)
 
-	if res.File != "" {
+	switch {
+	case res.EnvBound:
+		fmt.Fprintf(os.Stdout, "Using environment variables (config file not read)\n")
+	case res.File != "":
 		fmt.Fprintf(os.Stdout, "Using config file: %s\n", res.File)
 	}
 	for _, key := range cliconfig.Keys {
@@ -370,7 +384,7 @@ func rootFlagChanged(key string) bool {
 // activeResolution describes the configuration state this invocation resolved,
 // including which flags cmd actually saw.
 func activeResolution(cmd *cobra.Command) cliconfig.Resolution {
-	return cliconfig.NewResolution(activeProfile, loadedConfigFile, func(key string) bool {
+	return cliconfig.NewResolution(activeProfile, loadedConfigFile, envIsActiveSource, func(key string) bool {
 		f := cmd.Flags().Lookup(key)
 		return f != nil && f.Changed
 	})

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -154,8 +154,6 @@ var rootCmd = &cobra.Command{
 			url = url + "/api"
 		}
 
-		log.Debug("Using Server ", url)
-
 		httpSettings := settings.NewHttpSettings(url)
 
 		var apiClient *client.APIClient

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -348,7 +348,7 @@ func reportConfigSources() {
 
 	switch {
 	case res.EnvBound:
-		fmt.Fprintf(os.Stdout, "Using environment variables (config file not read)\n")
+		fmt.Fprintf(os.Stdout, "Using environment variables\n")
 	case res.File != "":
 		fmt.Fprintf(os.Stdout, "Using config file: %s\n", res.File)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -180,18 +180,9 @@ var rootCmd = &cobra.Command{
 			cachedExpiry := viper.GetInt64("cached-token-expiry")
 
 			// initConfig already resolved the profile; reuse it.
-			configPath, err := getConfigPath(activeProfile)
+			configPath, err := tokenCachePath(activeProfile)
 			if err != nil {
 				return fmt.Errorf("failed to get config path: %w", err)
-			}
-
-			// Only cache into the default config if it already exists.
-			// Creating it would plant a config.yaml on users running from the
-			// environment.
-			if cliconfig.IsDefault(activeProfile) {
-				if _, statErr := os.Stat(configPath); statErr != nil {
-					configPath = ""
-				}
 			}
 
 			tokenManager := NewCachedTokenManager(

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -181,18 +181,15 @@ var rootCmd = &cobra.Command{
 			cachedToken := viper.GetString("cached-token")
 			cachedExpiry := viper.GetInt64("cached-token-expiry")
 
-			// Determine config path for saving cached token. initConfig already
-			// resolved the profile, so reuse it rather than recomputing.
+			// initConfig already resolved the profile; reuse it.
 			configPath, err := getConfigPath(activeProfile)
 			if err != nil {
 				return fmt.Errorf("failed to get config path: %w", err)
 			}
 
-			// Caching into the default config is only safe when that file
-			// already exists. Creating it here would plant a config.yaml on
-			// users who deliberately run on environment variables alone, and
-			// that file would then start winning over their environment for
-			// every key it holds.
+			// Only cache into the default config if it already exists.
+			// Creating it would plant a config.yaml on users running from the
+			// environment.
 			if cliconfig.IsDefault(activeProfile) {
 				if _, statErr := os.Stat(configPath); statErr != nil {
 					configPath = ""
@@ -258,17 +255,14 @@ func Execute(ctx context.Context) {
 	}
 }
 
-// activeProfile is the profile initConfig settled on: the --profile flag, else
-// CONDUCTOR_PROFILE, else empty for the default configuration. `config show`
-// reports against it.
+// activeProfile is the profile initConfig settled on: --profile, else
+// CONDUCTOR_PROFILE, else "" for the default config.
 var activeProfile string
 
-// loadedConfigFile is the config file initConfig actually read, or "" when none
-// was found.
+// loadedConfigFile is the file initConfig read, or "" when none was.
 var loadedConfigFile string
 
-// effectiveProfile resolves which profile the CLI should use. The --profile flag
-// takes precedence over the CONDUCTOR_PROFILE environment variable.
+// effectiveProfile prefers the --profile flag over CONDUCTOR_PROFILE.
 func effectiveProfile() string {
 	if profile != "" {
 		return profile
@@ -276,8 +270,8 @@ func effectiveProfile() string {
 	return os.Getenv("CONDUCTOR_PROFILE")
 }
 
-// isSavingConfig reports whether this invocation is `config save`, which is
-// allowed to name a profile whose file does not exist yet.
+// isSavingConfig reports whether this is `config save`, which may name a profile
+// whose file does not exist yet.
 func isSavingConfig() bool {
 	for i, arg := range os.Args {
 		if arg == "config" && i+1 < len(os.Args) && os.Args[i+1] == "save" {
@@ -287,22 +281,19 @@ func isSavingConfig() bool {
 	return false
 }
 
-// envIsActiveSource is true when the environment supplied this invocation's
-// configuration, meaning no config file was read.
+// envIsActiveSource is true when the environment supplied the config, meaning no
+// file was read.
 var envIsActiveSource bool
 
 func initConfig() {
 	activeProfile = effectiveProfile()
 
-	// Naming a file is an explicit choice and wins over the ambient environment:
-	// --config names a path, --profile names one of the CLI's own files.
+	// Naming a file (--config or --profile) beats the ambient environment.
 	namedFile := cfgFile != "" || !cliconfig.IsDefault(activeProfile)
 
-	// Below flags, exactly one source supplies configuration. Naming a file
-	// selects that file; otherwise setting any CONDUCTOR_* variable selects the
-	// environment wholesale and the default config.yaml is not read. The two
-	// never merge: a value blended from both leaves no answer to "where did this
-	// come from".
+	// Below flags, exactly one source supplies config: a named file, else the
+	// environment if any variable is set, else config.yaml. They never merge — a
+	// blended value leaves no answer to "where did this come from".
 	envIsActiveSource = !namedFile && cliconfig.EnvActive()
 
 	if cfgFile != "" {
@@ -315,8 +306,7 @@ func initConfig() {
 		viper.AddConfigPath(configDir)
 		viper.SetConfigType("yaml")
 
-		// A named profile must already exist; the default configuration is
-		// optional, since the CLI also runs on flags and environment alone.
+		// A named profile must already exist; the default config is optional.
 		if !cliconfig.IsDefault(activeProfile) && !isSavingConfig() {
 			configPath := cliconfig.Resolve(configDir, activeProfile)
 			if _, err := os.Stat(configPath); os.IsNotExist(err) {
@@ -325,10 +315,9 @@ func initConfig() {
 			}
 		}
 
-		// Name the file explicitly, including "config" for the default. viper
-		// would find that name on its own, and relying on that is precisely how
-		// the default config kept loading after `config save` lost the ability
-		// to write it (#98).
+		// Name the file explicitly, including "config" for the default. Leaning
+		// on viper's identical built-in default is how the default config kept
+		// loading after config save lost the ability to write it (#98).
 		viper.SetConfigName(cliconfig.FileName(activeProfile))
 	}
 
@@ -342,8 +331,7 @@ func initConfig() {
 		viper.BindEnv("auth-token", "CONDUCTOR_AUTH_TOKEN")
 		viper.BindEnv("server-type", "CONDUCTOR_SERVER_TYPE")
 	} else {
-		// A missing config file is not an error: the CLI also runs on flags
-		// alone. Only a file that was read counts as a source.
+		// A missing file is not an error; only a file that was read is a source.
 		if err := viper.ReadInConfig(); err == nil {
 			loadedConfigFile = viper.ConfigFileUsed()
 		}
@@ -354,8 +342,7 @@ func initConfig() {
 	}
 }
 
-// reportConfigSources prints where each setting came from, so that a surprising
-// server URL can be traced without guessing between the environment and a file.
+// reportConfigSources prints where each setting came from.
 func reportConfigSources() {
 	res := cliconfig.NewResolution(activeProfile, loadedConfigFile, envIsActiveSource, rootFlagChanged)
 
@@ -370,7 +357,7 @@ func reportConfigSources() {
 		if src.Kind == cliconfig.SourceDefault {
 			continue
 		}
-		// The full path is already on the "Using config file" line above.
+		// The full path is already on the line above.
 		fmt.Fprintf(os.Stdout, "Using %s: %s (%s)\n", key, cliconfig.Mask(key, viper.GetString(key)), src.ShortString())
 	}
 }
@@ -381,8 +368,8 @@ func rootFlagChanged(key string) bool {
 	return f != nil && f.Changed
 }
 
-// activeResolution describes the configuration state this invocation resolved,
-// including which flags cmd actually saw.
+// activeResolution describes what this invocation resolved, including the flags
+// cmd saw.
 func activeResolution(cmd *cobra.Command) cliconfig.Resolution {
 	return cliconfig.NewResolution(activeProfile, loadedConfigFile, envIsActiveSource, func(key string) bool {
 		f := cmd.Flags().Lookup(key)

--- a/internal/cliconfig/cliconfig.go
+++ b/internal/cliconfig/cliconfig.go
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+// Package cliconfig resolves which configuration file the CLI reads and writes,
+// and explains where each resolved setting came from.
+//
+// Both questions used to be answered in three different places — config save,
+// config delete and initConfig each rebuilt the file name inline — which is how
+// the default config.yaml ended up readable but unwritable (#98). Everything
+// funnels through Resolve here so a rule can only be changed in one place.
+package cliconfig
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// DirName is the CLI's configuration directory, relative to the user's home.
+const DirName = ".conductor-cli"
+
+// DefaultProfileName is the name that refers to the default configuration file.
+// It is an alias, not a profile of its own: `--profile default` and no --profile
+// at all select the same file and the same precedence rules.
+const DefaultProfileName = "default"
+
+// defaultFileName is the file the CLI loads when no named profile is selected.
+// viper would find this name on its own, but relying on that default is what
+// made the read path outlive the write path in #98, so it is stated explicitly.
+const defaultFileName = "config"
+
+// Keys are the settings the CLI resolves from flags, environment and file.
+var Keys = []string{"server", "server-type", "auth-key", "auth-secret", "auth-token"}
+
+// envVars maps a config key to the environment variable bound to it. It mirrors
+// the BindEnv calls in cmd/root.go; the two must agree or reported sources lie.
+var envVars = map[string]string{
+	"server":      "CONDUCTOR_SERVER_URL",
+	"server-type": "CONDUCTOR_SERVER_TYPE",
+	"auth-key":    "CONDUCTOR_AUTH_KEY",
+	"auth-secret": "CONDUCTOR_AUTH_SECRET",
+	"auth-token":  "CONDUCTOR_AUTH_TOKEN",
+}
+
+// secretKeys are masked whenever a value is displayed.
+var secretKeys = map[string]bool{
+	"auth-secret": true,
+	"auth-token":  true,
+	"auth-key":    true,
+}
+
+// Dir returns the CLI configuration directory.
+func Dir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, DirName), nil
+}
+
+// IsDefault reports whether profile names the default configuration. An empty
+// name and "default" both do.
+func IsDefault(profile string) bool {
+	return profile == "" || profile == DefaultProfileName
+}
+
+// FileName returns the bare config file name for profile, without a directory
+// or extension — the form viper's SetConfigName expects.
+func FileName(profile string) string {
+	if IsDefault(profile) {
+		return defaultFileName
+	}
+	return "config-" + profile
+}
+
+// Resolve returns the absolute path of profile's config file within dir.
+// The default configuration is config.yaml; every named profile is
+// config-<profile>.yaml.
+func Resolve(dir, profile string) string {
+	return filepath.Join(dir, FileName(profile)+".yaml")
+}
+
+// EnvVar returns the environment variable bound to key, or "" if key has none.
+func EnvVar(key string) string {
+	return envVars[key]
+}
+
+// IsSecret reports whether key's value must be masked when displayed.
+func IsSecret(key string) bool {
+	return secretKeys[key]
+}
+
+// Mask renders value safely for display. Empty stays empty so that "unset" and
+// "set but hidden" remain distinguishable.
+func Mask(key, value string) string {
+	if value != "" && IsSecret(key) {
+		return "****"
+	}
+	return value
+}
+
+// StrayDefaultFile returns the path of a config-default.yaml in dir, or "" when
+// there is none.
+//
+// "default" now aliases config.yaml, so a literal config-default.yaml is
+// unreachable — earlier builds would happily create one via
+// `config save --profile default`. It is reported so the CLI can warn instead
+// of silently ignoring settings the user believes are active.
+func StrayDefaultFile(dir string) string {
+	path := filepath.Join(dir, "config-"+DefaultProfileName+".yaml")
+	if _, err := os.Stat(path); err != nil {
+		return ""
+	}
+	return path
+}

--- a/internal/cliconfig/cliconfig.go
+++ b/internal/cliconfig/cliconfig.go
@@ -94,6 +94,24 @@ func EnvVar(key string) string {
 	return envVars[key]
 }
 
+// EnvActive reports whether any configuration environment variable is set.
+//
+// The environment is an all-or-nothing source: if it supplies anything, it
+// supplies everything, and the default config file is not read. Blending the two
+// per key meant a user could not answer "where is this value coming from" without
+// checking both, so setting one variable now selects the environment outright.
+//
+// CONDUCTOR_PROFILE is deliberately excluded — it chooses a config file rather
+// than carrying a setting of its own.
+func EnvActive() bool {
+	for _, env := range envVars {
+		if os.Getenv(env) != "" {
+			return true
+		}
+	}
+	return false
+}
+
 // IsSecret reports whether key's value must be masked when displayed.
 func IsSecret(key string) bool {
 	return secretKeys[key]

--- a/internal/cliconfig/cliconfig.go
+++ b/internal/cliconfig/cliconfig.go
@@ -11,13 +11,12 @@
  * specific language governing permissions and limitations under the License.
  */
 
-// Package cliconfig resolves which configuration file the CLI reads and writes,
-// and explains where each resolved setting came from.
+// Package cliconfig resolves which config file the CLI reads and writes, and
+// where each resolved setting came from.
 //
-// Both questions used to be answered in three different places — config save,
-// config delete and initConfig each rebuilt the file name inline — which is how
-// the default config.yaml ended up readable but unwritable (#98). Everything
-// funnels through Resolve here so a rule can only be changed in one place.
+// Save, delete and initConfig each rebuilt the file name inline, which is how
+// config.yaml ended up readable but unwritable (#98). They all go through
+// Resolve now.
 package cliconfig
 
 import (
@@ -28,21 +27,20 @@ import (
 // DirName is the CLI's configuration directory, relative to the user's home.
 const DirName = ".conductor-cli"
 
-// DefaultProfileName is the name that refers to the default configuration file.
-// It is an alias, not a profile of its own: `--profile default` and no --profile
-// at all select the same file and the same precedence rules.
+// DefaultProfileName is an alias for the default config file, not a profile of
+// its own: `--profile default` and no --profile select the same file.
 const DefaultProfileName = "default"
 
-// defaultFileName is the file the CLI loads when no named profile is selected.
-// viper would find this name on its own, but relying on that default is what
-// made the read path outlive the write path in #98, so it is stated explicitly.
+// defaultFileName is loaded when no named profile is selected. Stated
+// explicitly: relying on viper's identical built-in default is what let the read
+// path outlive the write path (#98).
 const defaultFileName = "config"
 
 // Keys are the settings the CLI resolves from flags, environment and file.
 var Keys = []string{"server", "server-type", "auth-key", "auth-secret", "auth-token"}
 
-// envVars maps a config key to the environment variable bound to it. It mirrors
-// the BindEnv calls in cmd/root.go; the two must agree or reported sources lie.
+// envVars mirrors the BindEnv calls in cmd/root.go. The two must agree, or
+// reported sources lie.
 var envVars = map[string]string{
 	"server":      "CONDUCTOR_SERVER_URL",
 	"server-type": "CONDUCTOR_SERVER_TYPE",
@@ -67,14 +65,14 @@ func Dir() (string, error) {
 	return filepath.Join(home, DirName), nil
 }
 
-// IsDefault reports whether profile names the default configuration. An empty
-// name and "default" both do.
+// IsDefault reports whether profile names the default config. "" and "default"
+// both do.
 func IsDefault(profile string) bool {
 	return profile == "" || profile == DefaultProfileName
 }
 
-// FileName returns the bare config file name for profile, without a directory
-// or extension — the form viper's SetConfigName expects.
+// FileName returns the bare file name for profile, as viper's SetConfigName
+// expects it.
 func FileName(profile string) string {
 	if IsDefault(profile) {
 		return defaultFileName
@@ -82,9 +80,8 @@ func FileName(profile string) string {
 	return "config-" + profile
 }
 
-// Resolve returns the absolute path of profile's config file within dir.
-// The default configuration is config.yaml; every named profile is
-// config-<profile>.yaml.
+// Resolve returns the path of profile's config file within dir: config.yaml for
+// the default, config-<profile>.yaml otherwise.
 func Resolve(dir, profile string) string {
 	return filepath.Join(dir, FileName(profile)+".yaml")
 }
@@ -94,15 +91,12 @@ func EnvVar(key string) string {
 	return envVars[key]
 }
 
-// EnvActive reports whether any configuration environment variable is set.
+// EnvActive reports whether any config environment variable is set. The
+// environment is all-or-nothing: one variable selects it for everything, and the
+// default config file is not read.
 //
-// The environment is an all-or-nothing source: if it supplies anything, it
-// supplies everything, and the default config file is not read. Blending the two
-// per key meant a user could not answer "where is this value coming from" without
-// checking both, so setting one variable now selects the environment outright.
-//
-// CONDUCTOR_PROFILE is deliberately excluded — it chooses a config file rather
-// than carrying a setting of its own.
+// CONDUCTOR_PROFILE is excluded — it chooses a file rather than carrying a
+// setting.
 func EnvActive() bool {
 	for _, env := range envVars {
 		if os.Getenv(env) != "" {
@@ -117,8 +111,8 @@ func IsSecret(key string) bool {
 	return secretKeys[key]
 }
 
-// Mask renders value safely for display. Empty stays empty so that "unset" and
-// "set but hidden" remain distinguishable.
+// Mask hides a secret for display. Empty stays empty, so "unset" and "set but
+// hidden" stay distinguishable.
 func Mask(key, value string) string {
 	if value != "" && IsSecret(key) {
 		return "****"
@@ -126,13 +120,9 @@ func Mask(key, value string) string {
 	return value
 }
 
-// StrayDefaultFile returns the path of a config-default.yaml in dir, or "" when
-// there is none.
-//
-// "default" now aliases config.yaml, so a literal config-default.yaml is
-// unreachable — earlier builds would happily create one via
-// `config save --profile default`. It is reported so the CLI can warn instead
-// of silently ignoring settings the user believes are active.
+// StrayDefaultFile returns the path of a config-default.yaml in dir, or "".
+// Earlier builds could create one; it is unreachable now that "default" aliases
+// config.yaml, so callers warn rather than ignore it silently.
 func StrayDefaultFile(dir string) string {
 	path := filepath.Join(dir, "config-"+DefaultProfileName+".yaml")
 	if _, err := os.Stat(path); err != nil {

--- a/internal/cliconfig/cliconfig_test.go
+++ b/internal/cliconfig/cliconfig_test.go
@@ -110,25 +110,78 @@ func writeConfig(t *testing.T, dir, name, body string) string {
 	return path
 }
 
-func TestSourceOfDefaultProfileMergesEnvOverFile(t *testing.T) {
-	dir := t.TempDir()
-	file := writeConfig(t, dir, "config.yaml", "server: http://from-file\nauth-token: tok\n")
+func TestEnvActiveDetectsAnyConfigVariable(t *testing.T) {
+	for _, env := range envVars {
+		os.Unsetenv(env)
+	}
+	if EnvActive() {
+		t.Fatal("EnvActive() = true with no variables set")
+	}
 
+	// Any one variable selects the environment; it is all-or-nothing.
+	t.Setenv("CONDUCTOR_AUTH_TOKEN", "tok")
+	if !EnvActive() {
+		t.Error("EnvActive() = false with CONDUCTOR_AUTH_TOKEN set")
+	}
+}
+
+func TestEnvActiveIgnoresProfileSelector(t *testing.T) {
+	for _, env := range envVars {
+		os.Unsetenv(env)
+	}
+	// CONDUCTOR_PROFILE picks a file; it carries no setting of its own, so it
+	// must not switch the CLI onto the environment and away from that file.
+	t.Setenv("CONDUCTOR_PROFILE", "prod")
+	if EnvActive() {
+		t.Error("EnvActive() = true for CONDUCTOR_PROFILE alone")
+	}
+}
+
+func TestEnvActiveTreatsEmptyAsUnset(t *testing.T) {
+	for _, env := range envVars {
+		os.Unsetenv(env)
+	}
+	// An exported-but-empty variable is how shells leave a cleared value; it
+	// must not take the config file out of play.
+	t.Setenv("CONDUCTOR_SERVER_URL", "")
+	if EnvActive() {
+		t.Error("EnvActive() = true for an empty CONDUCTOR_SERVER_URL")
+	}
+}
+
+func TestSourceOfEnvSuppliesEverythingWhenActive(t *testing.T) {
+	dir := t.TempDir()
+	// The file holds an auth-token the environment does not. With the
+	// environment active the file is not read at all, so that token must not
+	// leak into the result — this is the merge the old behaviour produced.
+	file := writeConfig(t, dir, "config.yaml", "server: http://from-file\nauth-token: tok\n")
 	t.Setenv("CONDUCTOR_SERVER_URL", "http://from-env")
 	os.Unsetenv("CONDUCTOR_AUTH_TOKEN")
 
-	r := NewResolution("", file, nil)
+	// envBound=true means initConfig skipped the file, so no file is passed.
+	r := NewResolution("", "", true, nil)
 
-	// This merge is the behaviour users cannot currently see: env wins for the
-	// key it sets, and the file still supplies the rest.
 	if got := r.SourceOf("server"); got.Kind != SourceEnv || got.Detail != "CONDUCTOR_SERVER_URL" {
 		t.Errorf("server source = %+v, want env CONDUCTOR_SERVER_URL", got)
 	}
-	if got := r.SourceOf("auth-token"); got.Kind != SourceFile || got.Detail != file {
-		t.Errorf("auth-token source = %+v, want file %s", got, file)
+	if got := r.SourceOf("auth-token"); got.Kind != SourceDefault {
+		t.Errorf("auth-token source = %+v, want default — the file must not contribute", got)
 	}
-	if got := r.SourceOf("server-type"); got.Kind != SourceDefault {
-		t.Errorf("server-type source = %+v, want default", got)
+	_ = file
+}
+
+func TestSourceOfFileSuppliesEverythingWhenEnvUnset(t *testing.T) {
+	dir := t.TempDir()
+	file := writeConfig(t, dir, "config.yaml", "server: http://from-file\nauth-token: tok\n")
+	for _, env := range envVars {
+		os.Unsetenv(env)
+	}
+
+	r := NewResolution("", file, false, nil)
+	for _, key := range []string{"server", "auth-token"} {
+		if got := r.SourceOf(key); got.Kind != SourceFile || got.Detail != file {
+			t.Errorf("%s source = %+v, want file %s", key, got, file)
+		}
 	}
 }
 
@@ -136,12 +189,11 @@ func TestSourceOfNamedProfileIgnoresEnv(t *testing.T) {
 	dir := t.TempDir()
 	file := writeConfig(t, dir, "config-prod.yaml", "server: http://from-profile\n")
 
-	// The environment is set but not bound: cmd/root.go skips BindEnv when a
-	// named profile is active, so reporting env here would name a value that is
-	// not the one in use.
+	// The environment is set but not the active source: naming a file wins, so
+	// reporting env here would name a value that is not the one in use.
 	t.Setenv("CONDUCTOR_SERVER_URL", "http://from-env")
 
-	r := NewResolution("prod", file, nil)
+	r := NewResolution("prod", file, false, nil)
 	if r.EnvBound {
 		t.Error("EnvBound = true for a named profile, want false")
 	}
@@ -150,31 +202,19 @@ func TestSourceOfNamedProfileIgnoresEnv(t *testing.T) {
 	}
 }
 
-func TestSourceOfDefaultAliasBehavesLikeNoProfile(t *testing.T) {
-	dir := t.TempDir()
-	file := writeConfig(t, dir, "config.yaml", "server: http://from-file\n")
-	t.Setenv("CONDUCTOR_SERVER_URL", "http://from-env")
-
-	// "default" is an alias, so it must not flip the environment off the way a
-	// named profile does.
-	empty := NewResolution("", file, nil)
-	alias := NewResolution("default", file, nil)
-	if empty.SourceOf("server") != alias.SourceOf("server") {
-		t.Errorf("--profile default disagrees with no profile: %+v vs %+v",
-			alias.SourceOf("server"), empty.SourceOf("server"))
-	}
-}
-
 func TestSourceOfFlagBeatsEverything(t *testing.T) {
-	dir := t.TempDir()
-	file := writeConfig(t, dir, "config.yaml", "server: http://from-file\n")
 	t.Setenv("CONDUCTOR_SERVER_URL", "http://from-env")
 
+	// Flags remain per-key: overriding the server must not force the user to
+	// re-supply every credential.
 	changed := func(key string) bool { return key == "server" }
-	r := NewResolution("", file, changed)
+	r := NewResolution("", "", true, changed)
 
 	if got := r.SourceOf("server"); got.Kind != SourceFlag {
 		t.Errorf("server source = %+v, want flag", got)
+	}
+	if got := r.SourceOf("auth-token"); got.Kind == SourceFlag {
+		t.Errorf("auth-token source = %+v, want the active source, not flag", got)
 	}
 }
 
@@ -185,7 +225,7 @@ func TestSourceOfEmptyFileValueIsNotASource(t *testing.T) {
 	file := writeConfig(t, dir, "config.yaml", "server: \"\"\n")
 	os.Unsetenv("CONDUCTOR_SERVER_URL")
 
-	r := NewResolution("", file, nil)
+	r := NewResolution("", file, false, nil)
 	if got := r.SourceOf("server"); got.Kind != SourceDefault {
 		t.Errorf("server source = %+v, want default", got)
 	}
@@ -193,7 +233,7 @@ func TestSourceOfEmptyFileValueIsNotASource(t *testing.T) {
 
 func TestSourceOfMissingFileFallsBackCleanly(t *testing.T) {
 	os.Unsetenv("CONDUCTOR_SERVER_URL")
-	r := NewResolution("", filepath.Join(t.TempDir(), "absent.yaml"), nil)
+	r := NewResolution("", filepath.Join(t.TempDir(), "absent.yaml"), false, nil)
 	if got := r.SourceOf("server"); got.Kind != SourceDefault {
 		t.Errorf("server source = %+v, want default", got)
 	}

--- a/internal/cliconfig/cliconfig_test.go
+++ b/internal/cliconfig/cliconfig_test.go
@@ -26,9 +26,7 @@ func TestResolveMapsDefaultAndNamedProfiles(t *testing.T) {
 		profile string
 		want    string
 	}{
-		// The alias is the point of #98: an empty name and "default" must land
-		// on the same file, or config save writes somewhere config list is not
-		// looking.
+		// The alias is the point of #98: both must land on the same file.
 		{"empty name is the default config", "", "/cfg/config.yaml"},
 		{"default is an alias for the same file", "default", "/cfg/config.yaml"},
 		{"named profile", "prod", "/cfg/config-prod.yaml"},
@@ -93,8 +91,7 @@ func TestMaskHidesSecretsButKeepsUnsetDistinguishable(t *testing.T) {
 	if got := Mask("server", "http://localhost:8080/api"); got != "http://localhost:8080/api" {
 		t.Errorf("Mask(server) masked a non-secret: %q", got)
 	}
-	// An unset secret must not render as "****", or an empty config looks
-	// populated.
+	// An unset secret must not render as "****".
 	if got := Mask("auth-token", ""); got != "" {
 		t.Errorf("Mask(auth-token, empty) = %q, want empty", got)
 	}
@@ -118,7 +115,7 @@ func TestEnvActiveDetectsAnyConfigVariable(t *testing.T) {
 		t.Fatal("EnvActive() = true with no variables set")
 	}
 
-	// Any one variable selects the environment; it is all-or-nothing.
+	// Any one variable selects the environment.
 	t.Setenv("CONDUCTOR_AUTH_TOKEN", "tok")
 	if !EnvActive() {
 		t.Error("EnvActive() = false with CONDUCTOR_AUTH_TOKEN set")
@@ -129,8 +126,8 @@ func TestEnvActiveIgnoresProfileSelector(t *testing.T) {
 	for _, env := range envVars {
 		os.Unsetenv(env)
 	}
-	// CONDUCTOR_PROFILE picks a file; it carries no setting of its own, so it
-	// must not switch the CLI onto the environment and away from that file.
+	// CONDUCTOR_PROFILE picks a file, so it must not switch the CLI onto the
+	// environment and away from that file.
 	t.Setenv("CONDUCTOR_PROFILE", "prod")
 	if EnvActive() {
 		t.Error("EnvActive() = true for CONDUCTOR_PROFILE alone")
@@ -141,8 +138,7 @@ func TestEnvActiveTreatsEmptyAsUnset(t *testing.T) {
 	for _, env := range envVars {
 		os.Unsetenv(env)
 	}
-	// An exported-but-empty variable is how shells leave a cleared value; it
-	// must not take the config file out of play.
+	// An exported-but-empty variable must not take the config file out of play.
 	t.Setenv("CONDUCTOR_SERVER_URL", "")
 	if EnvActive() {
 		t.Error("EnvActive() = true for an empty CONDUCTOR_SERVER_URL")
@@ -150,24 +146,19 @@ func TestEnvActiveTreatsEmptyAsUnset(t *testing.T) {
 }
 
 func TestSourceOfEnvSuppliesEverythingWhenActive(t *testing.T) {
-	dir := t.TempDir()
-	// The file holds an auth-token the environment does not. With the
-	// environment active the file is not read at all, so that token must not
-	// leak into the result — this is the merge the old behaviour produced.
-	file := writeConfig(t, dir, "config.yaml", "server: http://from-file\nauth-token: tok\n")
 	t.Setenv("CONDUCTOR_SERVER_URL", "http://from-env")
 	os.Unsetenv("CONDUCTOR_AUTH_TOKEN")
 
-	// envBound=true means initConfig skipped the file, so no file is passed.
+	// envBound=true means initConfig skipped the file, so none is passed. Keys
+	// the environment does not set fall to default rather than to a file.
 	r := NewResolution("", "", true, nil)
 
 	if got := r.SourceOf("server"); got.Kind != SourceEnv || got.Detail != "CONDUCTOR_SERVER_URL" {
 		t.Errorf("server source = %+v, want env CONDUCTOR_SERVER_URL", got)
 	}
 	if got := r.SourceOf("auth-token"); got.Kind != SourceDefault {
-		t.Errorf("auth-token source = %+v, want default — the file must not contribute", got)
+		t.Errorf("auth-token source = %+v, want default", got)
 	}
-	_ = file
 }
 
 func TestSourceOfFileSuppliesEverythingWhenEnvUnset(t *testing.T) {
@@ -189,8 +180,7 @@ func TestSourceOfNamedProfileIgnoresEnv(t *testing.T) {
 	dir := t.TempDir()
 	file := writeConfig(t, dir, "config-prod.yaml", "server: http://from-profile\n")
 
-	// The environment is set but not the active source: naming a file wins, so
-	// reporting env here would name a value that is not the one in use.
+	// Set but not active: reporting env here would name an unused value.
 	t.Setenv("CONDUCTOR_SERVER_URL", "http://from-env")
 
 	r := NewResolution("prod", file, false, nil)
@@ -205,8 +195,7 @@ func TestSourceOfNamedProfileIgnoresEnv(t *testing.T) {
 func TestSourceOfFlagBeatsEverything(t *testing.T) {
 	t.Setenv("CONDUCTOR_SERVER_URL", "http://from-env")
 
-	// Flags remain per-key: overriding the server must not force the user to
-	// re-supply every credential.
+	// Flags are per-key: overriding server must not discard the credentials.
 	changed := func(key string) bool { return key == "server" }
 	r := NewResolution("", "", true, changed)
 
@@ -220,8 +209,7 @@ func TestSourceOfFlagBeatsEverything(t *testing.T) {
 
 func TestSourceOfEmptyFileValueIsNotASource(t *testing.T) {
 	dir := t.TempDir()
-	// A key present but blank supplies nothing; naming the file as the source
-	// would send a user to edit a line that is not responsible.
+	// A blank key supplies nothing, so naming the file would misdirect.
 	file := writeConfig(t, dir, "config.yaml", "server: \"\"\n")
 	os.Unsetenv("CONDUCTOR_SERVER_URL")
 
@@ -257,8 +245,7 @@ func TestSourceString(t *testing.T) {
 }
 
 func TestSourceShortString(t *testing.T) {
-	// The table in `config show` prints the full path in its header, so repeating
-	// it on every row only makes the column unreadable.
+	// config show prints the full path in its header already.
 	s := Source{Kind: SourceFile, Detail: "/home/u/.conductor-cli/config.yaml"}
 	if got := s.ShortString(); got != "config.yaml" {
 		t.Errorf("ShortString() = %q, want config.yaml", got)

--- a/internal/cliconfig/cliconfig_test.go
+++ b/internal/cliconfig/cliconfig_test.go
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package cliconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveMapsDefaultAndNamedProfiles(t *testing.T) {
+	dir := "/cfg"
+	tests := []struct {
+		name    string
+		profile string
+		want    string
+	}{
+		// The alias is the point of #98: an empty name and "default" must land
+		// on the same file, or config save writes somewhere config list is not
+		// looking.
+		{"empty name is the default config", "", "/cfg/config.yaml"},
+		{"default is an alias for the same file", "default", "/cfg/config.yaml"},
+		{"named profile", "prod", "/cfg/config-prod.yaml"},
+		{"name containing default is still named", "default-2", "/cfg/config-default-2.yaml"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Resolve(dir, tt.profile); got != tt.want {
+				t.Errorf("Resolve(%q) = %q, want %q", tt.profile, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFileNameMatchesViperConfigName(t *testing.T) {
+	if got := FileName(""); got != "config" {
+		t.Errorf(`FileName("") = %q, want "config"`, got)
+	}
+	if got := FileName("default"); got != "config" {
+		t.Errorf(`FileName("default") = %q, want "config"`, got)
+	}
+	if got := FileName("prod"); got != "config-prod" {
+		t.Errorf(`FileName("prod") = %q, want "config-prod"`, got)
+	}
+}
+
+func TestIsDefault(t *testing.T) {
+	for _, p := range []string{"", "default"} {
+		if !IsDefault(p) {
+			t.Errorf("IsDefault(%q) = false, want true", p)
+		}
+	}
+	for _, p := range []string{"prod", "Default", "default2"} {
+		if IsDefault(p) {
+			t.Errorf("IsDefault(%q) = true, want false", p)
+		}
+	}
+}
+
+func TestStrayDefaultFile(t *testing.T) {
+	dir := t.TempDir()
+	if got := StrayDefaultFile(dir); got != "" {
+		t.Errorf("StrayDefaultFile on clean dir = %q, want empty", got)
+	}
+
+	stray := filepath.Join(dir, "config-default.yaml")
+	if err := os.WriteFile(stray, []byte("server: http://x\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if got := StrayDefaultFile(dir); got != stray {
+		t.Errorf("StrayDefaultFile = %q, want %q", got, stray)
+	}
+}
+
+func TestMaskHidesSecretsButKeepsUnsetDistinguishable(t *testing.T) {
+	if got := Mask("auth-token", "abc123"); got != "****" {
+		t.Errorf("Mask(auth-token) = %q, want ****", got)
+	}
+	if got := Mask("auth-secret", "s3cret"); got != "****" {
+		t.Errorf("Mask(auth-secret) = %q, want ****", got)
+	}
+	if got := Mask("server", "http://localhost:8080/api"); got != "http://localhost:8080/api" {
+		t.Errorf("Mask(server) masked a non-secret: %q", got)
+	}
+	// An unset secret must not render as "****", or an empty config looks
+	// populated.
+	if got := Mask("auth-token", ""); got != "" {
+		t.Errorf("Mask(auth-token, empty) = %q, want empty", got)
+	}
+}
+
+// writeConfig writes a config file and returns its path.
+func writeConfig(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestSourceOfDefaultProfileMergesEnvOverFile(t *testing.T) {
+	dir := t.TempDir()
+	file := writeConfig(t, dir, "config.yaml", "server: http://from-file\nauth-token: tok\n")
+
+	t.Setenv("CONDUCTOR_SERVER_URL", "http://from-env")
+	os.Unsetenv("CONDUCTOR_AUTH_TOKEN")
+
+	r := NewResolution("", file, nil)
+
+	// This merge is the behaviour users cannot currently see: env wins for the
+	// key it sets, and the file still supplies the rest.
+	if got := r.SourceOf("server"); got.Kind != SourceEnv || got.Detail != "CONDUCTOR_SERVER_URL" {
+		t.Errorf("server source = %+v, want env CONDUCTOR_SERVER_URL", got)
+	}
+	if got := r.SourceOf("auth-token"); got.Kind != SourceFile || got.Detail != file {
+		t.Errorf("auth-token source = %+v, want file %s", got, file)
+	}
+	if got := r.SourceOf("server-type"); got.Kind != SourceDefault {
+		t.Errorf("server-type source = %+v, want default", got)
+	}
+}
+
+func TestSourceOfNamedProfileIgnoresEnv(t *testing.T) {
+	dir := t.TempDir()
+	file := writeConfig(t, dir, "config-prod.yaml", "server: http://from-profile\n")
+
+	// The environment is set but not bound: cmd/root.go skips BindEnv when a
+	// named profile is active, so reporting env here would name a value that is
+	// not the one in use.
+	t.Setenv("CONDUCTOR_SERVER_URL", "http://from-env")
+
+	r := NewResolution("prod", file, nil)
+	if r.EnvBound {
+		t.Error("EnvBound = true for a named profile, want false")
+	}
+	if got := r.SourceOf("server"); got.Kind != SourceFile || got.Detail != file {
+		t.Errorf("server source = %+v, want file %s", got, file)
+	}
+}
+
+func TestSourceOfDefaultAliasBehavesLikeNoProfile(t *testing.T) {
+	dir := t.TempDir()
+	file := writeConfig(t, dir, "config.yaml", "server: http://from-file\n")
+	t.Setenv("CONDUCTOR_SERVER_URL", "http://from-env")
+
+	// "default" is an alias, so it must not flip the environment off the way a
+	// named profile does.
+	empty := NewResolution("", file, nil)
+	alias := NewResolution("default", file, nil)
+	if empty.SourceOf("server") != alias.SourceOf("server") {
+		t.Errorf("--profile default disagrees with no profile: %+v vs %+v",
+			alias.SourceOf("server"), empty.SourceOf("server"))
+	}
+}
+
+func TestSourceOfFlagBeatsEverything(t *testing.T) {
+	dir := t.TempDir()
+	file := writeConfig(t, dir, "config.yaml", "server: http://from-file\n")
+	t.Setenv("CONDUCTOR_SERVER_URL", "http://from-env")
+
+	changed := func(key string) bool { return key == "server" }
+	r := NewResolution("", file, changed)
+
+	if got := r.SourceOf("server"); got.Kind != SourceFlag {
+		t.Errorf("server source = %+v, want flag", got)
+	}
+}
+
+func TestSourceOfEmptyFileValueIsNotASource(t *testing.T) {
+	dir := t.TempDir()
+	// A key present but blank supplies nothing; naming the file as the source
+	// would send a user to edit a line that is not responsible.
+	file := writeConfig(t, dir, "config.yaml", "server: \"\"\n")
+	os.Unsetenv("CONDUCTOR_SERVER_URL")
+
+	r := NewResolution("", file, nil)
+	if got := r.SourceOf("server"); got.Kind != SourceDefault {
+		t.Errorf("server source = %+v, want default", got)
+	}
+}
+
+func TestSourceOfMissingFileFallsBackCleanly(t *testing.T) {
+	os.Unsetenv("CONDUCTOR_SERVER_URL")
+	r := NewResolution("", filepath.Join(t.TempDir(), "absent.yaml"), nil)
+	if got := r.SourceOf("server"); got.Kind != SourceDefault {
+		t.Errorf("server source = %+v, want default", got)
+	}
+}
+
+func TestSourceString(t *testing.T) {
+	tests := []struct {
+		src  Source
+		want string
+	}{
+		{Source{Kind: SourceFlag, Detail: "server"}, "flag --server"},
+		{Source{Kind: SourceEnv, Detail: "CONDUCTOR_SERVER_URL"}, "env CONDUCTOR_SERVER_URL"},
+		{Source{Kind: SourceFile, Detail: "/cfg/config.yaml"}, "/cfg/config.yaml"},
+		{Source{Kind: SourceDefault}, "default"},
+	}
+	for _, tt := range tests {
+		if got := tt.src.String(); got != tt.want {
+			t.Errorf("Source%+v.String() = %q, want %q", tt.src, got, tt.want)
+		}
+	}
+}
+
+func TestSourceShortString(t *testing.T) {
+	// The table in `config show` prints the full path in its header, so repeating
+	// it on every row only makes the column unreadable.
+	s := Source{Kind: SourceFile, Detail: "/home/u/.conductor-cli/config.yaml"}
+	if got := s.ShortString(); got != "config.yaml" {
+		t.Errorf("ShortString() = %q, want config.yaml", got)
+	}
+	env := Source{Kind: SourceEnv, Detail: "CONDUCTOR_SERVER_URL"}
+	if got := env.ShortString(); got != "env CONDUCTOR_SERVER_URL" {
+		t.Errorf("ShortString() = %q, want the full env form", got)
+	}
+}

--- a/internal/cliconfig/source.go
+++ b/internal/cliconfig/source.go
@@ -71,9 +71,10 @@ type Resolution struct {
 	Profile string
 	// File is the config file that was loaded, or "" when none was found.
 	File string
-	// EnvBound reports whether environment variables are in play. They are not
-	// when a named profile is selected — cmd/root.go skips BindEnv so that an
-	// explicitly chosen profile wins over ambient environment.
+	// EnvBound reports whether the environment is the active source. Exactly one
+	// of EnvBound and File is in play: naming a file (--config or --profile)
+	// ignores the environment, and setting any configuration variable means the
+	// default config file is not read at all.
 	EnvBound bool
 	// fileKeys are the keys the loaded file supplied.
 	fileKeys map[string]bool
@@ -81,19 +82,20 @@ type Resolution struct {
 	flagChanged func(key string) bool
 }
 
-// NewResolution builds a Resolution for the given effective profile and config
-// file. A file that cannot be read contributes no keys, matching the CLI's
-// behaviour of running on flags and environment alone.
+// NewResolution builds a Resolution describing what the CLI loaded: the
+// effective profile, the config file that was read (empty when none was), and
+// whether the environment is the active source. A file that cannot be read
+// contributes no keys.
 //
 // flagChanged may be nil, in which case no key is attributed to a flag.
-func NewResolution(profile, file string, flagChanged func(key string) bool) Resolution {
+func NewResolution(profile, file string, envBound bool, flagChanged func(key string) bool) Resolution {
 	if flagChanged == nil {
 		flagChanged = func(string) bool { return false }
 	}
 	return Resolution{
 		Profile:     profile,
 		File:        file,
-		EnvBound:    IsDefault(profile),
+		EnvBound:    envBound,
 		fileKeys:    readKeys(file),
 		flagChanged: flagChanged,
 	}
@@ -106,10 +108,10 @@ func (r Resolution) IsDefaultProfile() bool {
 
 // SourceOf returns where key's effective value came from.
 //
-// The order mirrors viper's precedence — flag, environment, file, default — with
-// the environment step skipped when a named profile is active. Getting that skip
-// wrong would report a set CONDUCTOR_SERVER_URL as the live source while the
-// profile's value is the one actually used.
+// Flags override individual keys; below them exactly one source supplies the
+// rest, either the environment or a file. The environment step is skipped
+// whenever a file is the active source, so a set but unused CONDUCTOR_SERVER_URL
+// is never reported as live.
 func (r Resolution) SourceOf(key string) Source {
 	if r.flagChanged(key) {
 		return Source{Kind: SourceFlag, Detail: key}

--- a/internal/cliconfig/source.go
+++ b/internal/cliconfig/source.go
@@ -93,11 +93,6 @@ func NewResolution(profile, file string, envBound bool, flagChanged func(key str
 	}
 }
 
-// IsDefaultProfile reports whether the default config is in effect.
-func (r Resolution) IsDefaultProfile() bool {
-	return IsDefault(r.Profile)
-}
-
 // SourceOf returns where key's effective value came from. Flags override
 // individual keys; below them one source supplies the rest. The environment is
 // skipped when a file is active, so a set but unused variable is never reported

--- a/internal/cliconfig/source.go
+++ b/internal/cliconfig/source.go
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package cliconfig
+
+import (
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// SourceKind identifies where a resolved setting came from.
+type SourceKind string
+
+const (
+	SourceFlag    SourceKind = "flag"
+	SourceEnv     SourceKind = "env"
+	SourceFile    SourceKind = "file"
+	SourceDefault SourceKind = "default"
+)
+
+// Source is the origin of one resolved setting.
+type Source struct {
+	Kind SourceKind
+	// Detail names the origin: the flag, the environment variable, or the
+	// config file path. Empty for SourceDefault.
+	Detail string
+}
+
+// String renders the source for display, e.g. "env CONDUCTOR_SERVER_URL". File
+// sources carry their full path, for output that does not otherwise name it.
+func (s Source) String() string {
+	switch s.Kind {
+	case SourceFlag:
+		return "flag --" + s.Detail
+	case SourceEnv:
+		return "env " + s.Detail
+	case SourceFile:
+		return s.Detail
+	default:
+		return "default"
+	}
+}
+
+// ShortString is String with file sources reduced to a bare file name, for
+// output that already states the full path once.
+func (s Source) ShortString() string {
+	if s.Kind == SourceFile {
+		return filepath.Base(s.Detail)
+	}
+	return s.String()
+}
+
+// Resolution is the configuration state the CLI resolved at startup: which file
+// was loaded, whether environment variables participate, and which keys the file
+// actually supplied. It answers "where did this value come from" per key.
+type Resolution struct {
+	// Profile is the effective profile name. Empty or "default" means the
+	// default configuration.
+	Profile string
+	// File is the config file that was loaded, or "" when none was found.
+	File string
+	// EnvBound reports whether environment variables are in play. They are not
+	// when a named profile is selected — cmd/root.go skips BindEnv so that an
+	// explicitly chosen profile wins over ambient environment.
+	EnvBound bool
+	// fileKeys are the keys the loaded file supplied.
+	fileKeys map[string]bool
+	// flagChanged reports whether the user passed the flag for a key.
+	flagChanged func(key string) bool
+}
+
+// NewResolution builds a Resolution for the given effective profile and config
+// file. A file that cannot be read contributes no keys, matching the CLI's
+// behaviour of running on flags and environment alone.
+//
+// flagChanged may be nil, in which case no key is attributed to a flag.
+func NewResolution(profile, file string, flagChanged func(key string) bool) Resolution {
+	if flagChanged == nil {
+		flagChanged = func(string) bool { return false }
+	}
+	return Resolution{
+		Profile:     profile,
+		File:        file,
+		EnvBound:    IsDefault(profile),
+		fileKeys:    readKeys(file),
+		flagChanged: flagChanged,
+	}
+}
+
+// IsDefaultProfile reports whether the default configuration is in effect.
+func (r Resolution) IsDefaultProfile() bool {
+	return IsDefault(r.Profile)
+}
+
+// SourceOf returns where key's effective value came from.
+//
+// The order mirrors viper's precedence — flag, environment, file, default — with
+// the environment step skipped when a named profile is active. Getting that skip
+// wrong would report a set CONDUCTOR_SERVER_URL as the live source while the
+// profile's value is the one actually used.
+func (r Resolution) SourceOf(key string) Source {
+	if r.flagChanged(key) {
+		return Source{Kind: SourceFlag, Detail: key}
+	}
+	if r.EnvBound {
+		if env := EnvVar(key); env != "" && os.Getenv(env) != "" {
+			return Source{Kind: SourceEnv, Detail: env}
+		}
+	}
+	if r.fileKeys[key] {
+		return Source{Kind: SourceFile, Detail: r.File}
+	}
+	return Source{Kind: SourceDefault}
+}
+
+// readKeys returns the top-level keys present in the YAML file at path. A
+// missing or malformed file yields no keys rather than an error: the CLI still
+// runs on flags and environment, and the caller only needs to know what the file
+// contributed.
+func readKeys(path string) map[string]bool {
+	keys := map[string]bool{}
+	if path == "" {
+		return keys
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return keys
+	}
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return keys
+	}
+	for k, v := range raw {
+		// A key present but empty supplies nothing, and reporting it as the
+		// source would point at a file that did not set the value.
+		if s, ok := v.(string); ok && s == "" {
+			continue
+		}
+		keys[k] = true
+	}
+	return keys
+}

--- a/internal/cliconfig/source.go
+++ b/internal/cliconfig/source.go
@@ -38,8 +38,8 @@ type Source struct {
 	Detail string
 }
 
-// String renders the source for display, e.g. "env CONDUCTOR_SERVER_URL". File
-// sources carry their full path, for output that does not otherwise name it.
+// String renders the source, e.g. "env CONDUCTOR_SERVER_URL". Files carry their
+// full path.
 func (s Source) String() string {
 	switch s.Kind {
 	case SourceFlag:
@@ -53,8 +53,8 @@ func (s Source) String() string {
 	}
 }
 
-// ShortString is String with file sources reduced to a bare file name, for
-// output that already states the full path once.
+// ShortString is String with files reduced to a bare name, for output that
+// already states the path once.
 func (s Source) ShortString() string {
 	if s.Kind == SourceFile {
 		return filepath.Base(s.Detail)
@@ -62,19 +62,15 @@ func (s Source) ShortString() string {
 	return s.String()
 }
 
-// Resolution is the configuration state the CLI resolved at startup: which file
-// was loaded, whether environment variables participate, and which keys the file
-// actually supplied. It answers "where did this value come from" per key.
+// Resolution is the config state the CLI resolved at startup. It answers "where
+// did this value come from" per key.
 type Resolution struct {
-	// Profile is the effective profile name. Empty or "default" means the
-	// default configuration.
+	// Profile is the effective profile name; "" or "default" is the default config.
 	Profile string
-	// File is the config file that was loaded, or "" when none was found.
+	// File is the config file that was loaded, or "" when none was.
 	File string
 	// EnvBound reports whether the environment is the active source. Exactly one
-	// of EnvBound and File is in play: naming a file (--config or --profile)
-	// ignores the environment, and setting any configuration variable means the
-	// default config file is not read at all.
+	// of EnvBound and File is ever in play.
 	EnvBound bool
 	// fileKeys are the keys the loaded file supplied.
 	fileKeys map[string]bool
@@ -82,12 +78,8 @@ type Resolution struct {
 	flagChanged func(key string) bool
 }
 
-// NewResolution builds a Resolution describing what the CLI loaded: the
-// effective profile, the config file that was read (empty when none was), and
-// whether the environment is the active source. A file that cannot be read
-// contributes no keys.
-//
-// flagChanged may be nil, in which case no key is attributed to a flag.
+// NewResolution builds a Resolution from what the CLI loaded. An unreadable file
+// contributes no keys. flagChanged may be nil.
 func NewResolution(profile, file string, envBound bool, flagChanged func(key string) bool) Resolution {
 	if flagChanged == nil {
 		flagChanged = func(string) bool { return false }
@@ -101,17 +93,15 @@ func NewResolution(profile, file string, envBound bool, flagChanged func(key str
 	}
 }
 
-// IsDefaultProfile reports whether the default configuration is in effect.
+// IsDefaultProfile reports whether the default config is in effect.
 func (r Resolution) IsDefaultProfile() bool {
 	return IsDefault(r.Profile)
 }
 
-// SourceOf returns where key's effective value came from.
-//
-// Flags override individual keys; below them exactly one source supplies the
-// rest, either the environment or a file. The environment step is skipped
-// whenever a file is the active source, so a set but unused CONDUCTOR_SERVER_URL
-// is never reported as live.
+// SourceOf returns where key's effective value came from. Flags override
+// individual keys; below them one source supplies the rest. The environment is
+// skipped when a file is active, so a set but unused variable is never reported
+// as live.
 func (r Resolution) SourceOf(key string) Source {
 	if r.flagChanged(key) {
 		return Source{Kind: SourceFlag, Detail: key}
@@ -127,10 +117,8 @@ func (r Resolution) SourceOf(key string) Source {
 	return Source{Kind: SourceDefault}
 }
 
-// readKeys returns the top-level keys present in the YAML file at path. A
-// missing or malformed file yields no keys rather than an error: the CLI still
-// runs on flags and environment, and the caller only needs to know what the file
-// contributed.
+// readKeys returns the top-level keys in the YAML file at path. A missing or
+// malformed file yields no keys rather than an error.
 func readKeys(path string) map[string]bool {
 	keys := map[string]bool{}
 	if path == "" {
@@ -145,8 +133,7 @@ func readKeys(path string) map[string]bool {
 		return keys
 	}
 	for k, v := range raw {
-		// A key present but empty supplies nothing, and reporting it as the
-		// source would point at a file that did not set the value.
+		// A blank key supplies nothing; naming the file would misdirect.
 		if s, ok := v.(string); ok && s == "" {
 			continue
 		}

--- a/test/e2e/config.bats
+++ b/test/e2e/config.bats
@@ -97,8 +97,8 @@ save_profile() {
     [ "$status" -eq 0 ]
 }
 
-# The default config lives at a fixed path inside HOME, so these tests run
-# against a throwaway HOME. Without it they would overwrite the developer's real
+# The default config lives at a fixed path inside HOME, so these tests use a
+# throwaway one. Without it they would overwrite the developer's real
 # ~/.conductor-cli/config.yaml.
 isolated_home() {
     local home
@@ -107,11 +107,9 @@ isolated_home() {
     echo "$home"
 }
 
-# Any configuration variable switches the CLI onto the environment and stops it
-# reading the config file. CI exports CONDUCTOR_SERVER_URL and
-# CONDUCTOR_SERVER_TYPE for the whole run, so a test that wants the file to be
-# the active source has to clear all of them — clearing only the one it cares
-# about leaves the others holding the CLI on the environment.
+# Any config variable switches the CLI onto the environment. CI exports
+# CONDUCTOR_SERVER_URL and CONDUCTOR_SERVER_TYPE for the whole run, so tests that
+# want the file to win must clear all of them, not just the one they care about.
 NO_CONFIG_ENV="env -u CONDUCTOR_SERVER_URL -u CONDUCTOR_SERVER_TYPE -u CONDUCTOR_AUTH_KEY -u CONDUCTOR_AUTH_SECRET -u CONDUCTOR_AUTH_TOKEN"
 
 @test "8. Save with an empty profile name writes the default config" {
@@ -125,8 +123,7 @@ NO_CONFIG_ENV="env -u CONDUCTOR_SERVER_URL -u CONDUCTOR_SERVER_TYPE -u CONDUCTOR
     rm -rf "$home"
 }
 
-# Regression guard for #98: the default profile (~/.conductor-cli/config.yaml)
-# was still read but could not be created or updated through the CLI.
+# Regression guard for #98: config.yaml was read but not writable.
 @test "9. Default profile can be managed through the CLI" {
     local home
     home="$(isolated_home)"
@@ -155,7 +152,7 @@ NO_CONFIG_ENV="env -u CONDUCTOR_SERVER_URL -u CONDUCTOR_SERVER_TYPE -u CONDUCTOR
     [ "$status" -eq 0 ]
     [[ "$output" == *"config.yaml"* ]]
 
-    # The alias must not create a second, unreachable config-default.yaml.
+    # The alias must not create a second, unreachable file.
     [ -f "$home/.conductor-cli/config.yaml" ]
     [ ! -f "$home/.conductor-cli/config-default.yaml" ]
     rm -rf "$home"
@@ -200,14 +197,12 @@ NO_CONFIG_ENV="env -u CONDUCTOR_SERVER_URL -u CONDUCTOR_SERVER_TYPE -u CONDUCTOR
 @test "14. Setting an env var takes the config file out of play entirely" {
     local home
     home="$(isolated_home)"
-    # The file carries a token the environment does not. The environment sets
-    # only the server URL; the token must not be picked up from the file.
+    # The file carries a token the environment does not; it must not be used.
     printf 'server: http://from-file:8080/api\nauth-token: tok-from-file\nserver-type: OSS\n' \
         > "$home/.conductor-cli/config.yaml"
 
-    # Only the server URL comes from the environment. The auth variables are
-    # cleared because the Enterprise runner exports real ones, and a "****" from
-    # the environment is not evidence about the file either way.
+    # Clear the auth variables: the Enterprise runner exports real ones, and a
+    # "****" sourced from the environment says nothing about the file.
     run bash -c "env -u CONDUCTOR_AUTH_KEY -u CONDUCTOR_AUTH_SECRET -u CONDUCTOR_AUTH_TOKEN \
         HOME='$home' CONDUCTOR_SERVER_URL=http://from-env:9999/api ./conductor config show 2>&1"
     echo "Output: $output"
@@ -216,8 +211,7 @@ NO_CONFIG_ENV="env -u CONDUCTOR_SERVER_URL -u CONDUCTOR_SERVER_TYPE -u CONDUCTOR
     [[ "$output" != *"from-file"* ]]
     [[ "$output" == *"config file not read"* ]]
 
-    # The file's auth-token must not be picked up: no value, and no attribution
-    # to the config file.
+    # The file's auth-token must not be picked up.
     token_row="$(echo "$output" | grep '^auth-token')"
     echo "auth-token row: $token_row"
     [[ "$token_row" != *"config.yaml"* ]]
@@ -258,7 +252,7 @@ NO_CONFIG_ENV="env -u CONDUCTOR_SERVER_URL -u CONDUCTOR_SERVER_TYPE -u CONDUCTOR
     [ "$status" -eq 0 ]
     [[ "$output" == *"from-flag"* ]]
     [[ "$output" == *"flag --server"* ]]
-    # The token still comes from the file: flags are per-key, not a source switch.
+    # Token still from the file: flags are per-key, not a source switch.
     [[ "$output" == *"****"* ]]
     rm -rf "$home"
 }

--- a/test/e2e/config.bats
+++ b/test/e2e/config.bats
@@ -181,13 +181,68 @@ isolated_home() {
     [[ "$output" == *"from-file"* ]]
     [[ "$output" == *"config.yaml"* ]]
 
-    # With the environment set, the merge is visible: env wins for server, the
-    # file still supplies server-type.
     run bash -c "HOME='$home' CONDUCTOR_SERVER_URL=http://from-env:9999/api ./conductor config show 2>&1"
     echo "Output: $output"
     [ "$status" -eq 0 ]
     [[ "$output" == *"env CONDUCTOR_SERVER_URL"* ]]
     [[ "$output" == *"from-env"* ]]
+    [[ "$output" == *"config file not read"* ]]
+    rm -rf "$home"
+}
+
+@test "14. Setting an env var takes the config file out of play entirely" {
+    local home
+    home="$(isolated_home)"
+    # The file carries a token the environment does not. The environment sets
+    # only the server URL; the token must not be picked up from the file.
+    printf 'server: http://from-file:8080/api\nauth-token: tok-from-file\nserver-type: OSS\n' \
+        > "$home/.conductor-cli/config.yaml"
+
+    run bash -c "HOME='$home' CONDUCTOR_SERVER_URL=http://from-env:9999/api ./conductor config show 2>&1"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"from-env"* ]]
+    [[ "$output" != *"from-file"* ]]
+    # auth-token has no value at all, rather than the file's.
+    [[ "$output" != *"****"* ]]
+    rm -rf "$home"
+}
+
+@test "15. Naming a file beats the environment" {
+    local home
+    home="$(isolated_home)"
+    printf 'server: http://from-profile:7777/api\nserver-type: OSS\n' > "$home/.conductor-cli/config-e2eprof.yaml"
+    printf 'server: http://from-explicit:6666/api\nserver-type: OSS\n' > "$home/explicit.yaml"
+
+    # --profile names one of the CLI's files.
+    run bash -c "HOME='$home' CONDUCTOR_SERVER_URL=http://from-env:9999/api ./conductor --profile e2eprof config show 2>&1"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"from-profile"* ]]
+    [[ "$output" != *"from-env"* ]]
+
+    # --config names an arbitrary path.
+    run bash -c "HOME='$home' CONDUCTOR_SERVER_URL=http://from-env:9999/api ./conductor --config '$home/explicit.yaml' config show 2>&1"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"from-explicit"* ]]
+    [[ "$output" != *"from-env"* ]]
+    rm -rf "$home"
+}
+
+@test "16. A flag overrides one key without discarding the rest" {
+    local home
+    home="$(isolated_home)"
+    printf 'server: http://from-file:8080/api\nauth-token: tok-from-file\nserver-type: OSS\n' \
+        > "$home/.conductor-cli/config.yaml"
+
+    run bash -c "HOME='$home' CONDUCTOR_SERVER_URL= ./conductor --server http://from-flag:1111/api config show 2>&1"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"from-flag"* ]]
+    [[ "$output" == *"flag --server"* ]]
+    # The token still comes from the file: flags are per-key, not a source switch.
+    [[ "$output" == *"****"* ]]
     rm -rf "$home"
 }
 

--- a/test/e2e/config.bats
+++ b/test/e2e/config.bats
@@ -107,6 +107,13 @@ isolated_home() {
     echo "$home"
 }
 
+# Any configuration variable switches the CLI onto the environment and stops it
+# reading the config file. CI exports CONDUCTOR_SERVER_URL and
+# CONDUCTOR_SERVER_TYPE for the whole run, so a test that wants the file to be
+# the active source has to clear all of them — clearing only the one it cares
+# about leaves the others holding the CLI on the environment.
+NO_CONFIG_ENV="env -u CONDUCTOR_SERVER_URL -u CONDUCTOR_SERVER_TYPE -u CONDUCTOR_AUTH_KEY -u CONDUCTOR_AUTH_SECRET -u CONDUCTOR_AUTH_TOKEN"
+
 @test "8. Save with an empty profile name writes the default config" {
     local home
     home="$(isolated_home)"
@@ -175,7 +182,7 @@ isolated_home() {
     printf 'server: http://from-file:8080/api\nserver-type: OSS\n' > "$home/.conductor-cli/config.yaml"
 
     # File supplies the value when the environment does not.
-    run bash -c "HOME='$home' CONDUCTOR_SERVER_URL= ./conductor config show 2>&1"
+    run bash -c "$NO_CONFIG_ENV HOME='$home' ./conductor config show 2>&1"
     echo "Output: $output"
     [ "$status" -eq 0 ]
     [[ "$output" == *"from-file"* ]]
@@ -236,7 +243,7 @@ isolated_home() {
     printf 'server: http://from-file:8080/api\nauth-token: tok-from-file\nserver-type: OSS\n' \
         > "$home/.conductor-cli/config.yaml"
 
-    run bash -c "HOME='$home' CONDUCTOR_SERVER_URL= ./conductor --server http://from-flag:1111/api config show 2>&1"
+    run bash -c "$NO_CONFIG_ENV HOME='$home' ./conductor --server http://from-flag:1111/api config show 2>&1"
     echo "Output: $output"
     [ "$status" -eq 0 ]
     [[ "$output" == *"from-flag"* ]]
@@ -251,13 +258,13 @@ isolated_home() {
     home="$(isolated_home)"
     printf 'server: http://x:8080/api\nauth-token: supersecrettoken\n' > "$home/.conductor-cli/config.yaml"
 
-    run bash -c "HOME='$home' ./conductor config show 2>&1"
+    run bash -c "$NO_CONFIG_ENV HOME='$home' ./conductor config show 2>&1"
     echo "Output: $output"
     [ "$status" -eq 0 ]
     [[ "$output" != *"supersecrettoken"* ]]
     [[ "$output" == *"****"* ]]
 
-    run bash -c "HOME='$home' ./conductor config show --show-secrets 2>&1"
+    run bash -c "$NO_CONFIG_ENV HOME='$home' ./conductor config show --show-secrets 2>&1"
     [ "$status" -eq 0 ]
     [[ "$output" == *"supersecrettoken"* ]]
     rm -rf "$home"

--- a/test/e2e/config.bats
+++ b/test/e2e/config.bats
@@ -190,7 +190,7 @@ NO_CONFIG_ENV="env -u CONDUCTOR_SERVER_URL -u CONDUCTOR_SERVER_TYPE -u CONDUCTOR
     [ "$status" -eq 0 ]
     [[ "$output" == *"env CONDUCTOR_SERVER_URL"* ]]
     [[ "$output" == *"from-env"* ]]
-    [[ "$output" == *"config file not read"* ]]
+    [[ "$output" == *"Source: environment variables"* ]]
     rm -rf "$home"
 }
 
@@ -209,7 +209,7 @@ NO_CONFIG_ENV="env -u CONDUCTOR_SERVER_URL -u CONDUCTOR_SERVER_TYPE -u CONDUCTOR
     [ "$status" -eq 0 ]
     [[ "$output" == *"from-env"* ]]
     [[ "$output" != *"from-file"* ]]
-    [[ "$output" == *"config file not read"* ]]
+    [[ "$output" == *"Source: environment variables"* ]]
 
     # The file's auth-token must not be picked up.
     token_row="$(echo "$output" | grep '^auth-token')"

--- a/test/e2e/config.bats
+++ b/test/e2e/config.bats
@@ -194,6 +194,23 @@ NO_CONFIG_ENV="env -u CONDUCTOR_SERVER_URL -u CONDUCTOR_SERVER_TYPE -u CONDUCTOR
     rm -rf "$home"
 }
 
+@test "13. config show masks secrets unless asked" {
+    local home
+    home="$(isolated_home)"
+    printf 'server: http://x:8080/api\nauth-token: supersecrettoken\n' > "$home/.conductor-cli/config.yaml"
+
+    run bash -c "$NO_CONFIG_ENV HOME='$home' ./conductor config show 2>&1"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"supersecrettoken"* ]]
+    [[ "$output" == *"****"* ]]
+
+    run bash -c "$NO_CONFIG_ENV HOME='$home' ./conductor config show --show-secrets 2>&1"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"supersecrettoken"* ]]
+    rm -rf "$home"
+}
+
 @test "14. Setting an env var takes the config file out of play entirely" {
     local home
     home="$(isolated_home)"
@@ -254,22 +271,5 @@ NO_CONFIG_ENV="env -u CONDUCTOR_SERVER_URL -u CONDUCTOR_SERVER_TYPE -u CONDUCTOR
     [[ "$output" == *"flag --server"* ]]
     # Token still from the file: flags are per-key, not a source switch.
     [[ "$output" == *"****"* ]]
-    rm -rf "$home"
-}
-
-@test "13. config show masks secrets unless asked" {
-    local home
-    home="$(isolated_home)"
-    printf 'server: http://x:8080/api\nauth-token: supersecrettoken\n' > "$home/.conductor-cli/config.yaml"
-
-    run bash -c "$NO_CONFIG_ENV HOME='$home' ./conductor config show 2>&1"
-    echo "Output: $output"
-    [ "$status" -eq 0 ]
-    [[ "$output" != *"supersecrettoken"* ]]
-    [[ "$output" == *"****"* ]]
-
-    run bash -c "$NO_CONFIG_ENV HOME='$home' ./conductor config show --show-secrets 2>&1"
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"supersecrettoken"* ]]
     rm -rf "$home"
 }

--- a/test/e2e/config.bats
+++ b/test/e2e/config.bats
@@ -205,13 +205,23 @@ NO_CONFIG_ENV="env -u CONDUCTOR_SERVER_URL -u CONDUCTOR_SERVER_TYPE -u CONDUCTOR
     printf 'server: http://from-file:8080/api\nauth-token: tok-from-file\nserver-type: OSS\n' \
         > "$home/.conductor-cli/config.yaml"
 
-    run bash -c "HOME='$home' CONDUCTOR_SERVER_URL=http://from-env:9999/api ./conductor config show 2>&1"
+    # Only the server URL comes from the environment. The auth variables are
+    # cleared because the Enterprise runner exports real ones, and a "****" from
+    # the environment is not evidence about the file either way.
+    run bash -c "env -u CONDUCTOR_AUTH_KEY -u CONDUCTOR_AUTH_SECRET -u CONDUCTOR_AUTH_TOKEN \
+        HOME='$home' CONDUCTOR_SERVER_URL=http://from-env:9999/api ./conductor config show 2>&1"
     echo "Output: $output"
     [ "$status" -eq 0 ]
     [[ "$output" == *"from-env"* ]]
     [[ "$output" != *"from-file"* ]]
-    # auth-token has no value at all, rather than the file's.
-    [[ "$output" != *"****"* ]]
+    [[ "$output" == *"config file not read"* ]]
+
+    # The file's auth-token must not be picked up: no value, and no attribution
+    # to the config file.
+    token_row="$(echo "$output" | grep '^auth-token')"
+    echo "auth-token row: $token_row"
+    [[ "$token_row" != *"config.yaml"* ]]
+    [[ "$token_row" != *"****"* ]]
     rm -rf "$home"
 }
 

--- a/test/e2e/config.bats
+++ b/test/e2e/config.bats
@@ -97,22 +97,113 @@ save_profile() {
     [ "$status" -eq 0 ]
 }
 
-@test "8. Save without a profile name is rejected" {
-    # config save always targets config-<name>.yaml; with no --profile it prompts,
-    # and empty input is an error rather than a default-profile write.
-    run bash -c "printf '\n' | ./conductor config save 2>&1"
-    echo "Output: $output"
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"profile name is required"* ]]
+# The default config lives at a fixed path inside HOME, so these tests run
+# against a throwaway HOME. Without it they would overwrite the developer's real
+# ~/.conductor-cli/config.yaml.
+isolated_home() {
+    local home
+    home="$(mktemp -d)"
+    mkdir -p "$home/.conductor-cli"
+    echo "$home"
 }
 
-# Regression guard for #98: the default profile (~/.conductor-cli/config.yaml) is
-# still read but cannot be created or updated through the CLI. Asserts the
-# desired end state.
-@test "9. Default profile can be managed through the CLI" {
-    skip "known broken: #98 — config save cannot write the default config.yaml"
-    run bash -c "printf '\n\n\n\n\n' | ./conductor config save 2>&1"
+@test "8. Save with an empty profile name writes the default config" {
+    local home
+    home="$(isolated_home)"
+    run bash -c "printf '\n\n\n\n\n' | HOME='$home' ./conductor config save 2>&1"
     echo "Output: $output"
     [ "$status" -eq 0 ]
     [[ "$output" == *"config.yaml"* ]]
+    [ -f "$home/.conductor-cli/config.yaml" ]
+    rm -rf "$home"
+}
+
+# Regression guard for #98: the default profile (~/.conductor-cli/config.yaml)
+# was still read but could not be created or updated through the CLI.
+@test "9. Default profile can be managed through the CLI" {
+    local home
+    home="$(isolated_home)"
+
+    run bash -c "printf '\n\n\n\n\n' | HOME='$home' ./conductor config save 2>&1"
+    [ "$status" -eq 0 ]
+
+    run bash -c "HOME='$home' ./conductor config list 2>&1"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"default"* ]]
+
+    run bash -c "HOME='$home' ./conductor config delete default -y 2>&1"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    [ ! -f "$home/.conductor-cli/config.yaml" ]
+    rm -rf "$home"
+}
+
+@test "10. --profile default writes the same file as an empty name" {
+    local home
+    home="$(isolated_home)"
+
+    run bash -c "printf '\n\n\n\n\n' | HOME='$home' ./conductor config save --profile default 2>&1"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"config.yaml"* ]]
+
+    # The alias must not create a second, unreachable config-default.yaml.
+    [ -f "$home/.conductor-cli/config.yaml" ]
+    [ ! -f "$home/.conductor-cli/config-default.yaml" ]
+    rm -rf "$home"
+}
+
+@test "11. A stray config-default.yaml is reported, not listed" {
+    local home
+    home="$(isolated_home)"
+    printf 'server: http://stray:8080/api\n' > "$home/.conductor-cli/config-default.yaml"
+    printf 'server: http://real:8080/api\n' > "$home/.conductor-cli/config.yaml"
+
+    run bash -c "HOME='$home' ./conductor config list 2>&1"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"config-default.yaml is not used"* ]]
+    # "default" must appear once, for config.yaml only.
+    [ "$(echo "$output" | grep -cx 'default')" -eq 1 ]
+    rm -rf "$home"
+}
+
+@test "12. config show reports the source of each value" {
+    local home
+    home="$(isolated_home)"
+    printf 'server: http://from-file:8080/api\nserver-type: OSS\n' > "$home/.conductor-cli/config.yaml"
+
+    # File supplies the value when the environment does not.
+    run bash -c "HOME='$home' CONDUCTOR_SERVER_URL= ./conductor config show 2>&1"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"from-file"* ]]
+    [[ "$output" == *"config.yaml"* ]]
+
+    # With the environment set, the merge is visible: env wins for server, the
+    # file still supplies server-type.
+    run bash -c "HOME='$home' CONDUCTOR_SERVER_URL=http://from-env:9999/api ./conductor config show 2>&1"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"env CONDUCTOR_SERVER_URL"* ]]
+    [[ "$output" == *"from-env"* ]]
+    rm -rf "$home"
+}
+
+@test "13. config show masks secrets unless asked" {
+    local home
+    home="$(isolated_home)"
+    printf 'server: http://x:8080/api\nauth-token: supersecrettoken\n' > "$home/.conductor-cli/config.yaml"
+
+    run bash -c "HOME='$home' ./conductor config show 2>&1"
+    echo "Output: $output"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"supersecrettoken"* ]]
+    [[ "$output" == *"****"* ]]
+
+    run bash -c "HOME='$home' ./conductor config show --show-secrets 2>&1"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"supersecrettoken"* ]]
+    rm -rf "$home"
 }


### PR DESCRIPTION
Fixes #98.

tl;dr:
```
1. Makes the default config file writable again
2. One source at a time: env vars or the config file, never both
3. Adds command conductor config show
4. Updates README.md and CLAUDE.md
```
## What was wrong

Two things, both about the default configuration.

**1. It was readable but not writable.** `conductor config save` could only create `config-<name>.yaml`, yet the CLI still loaded `~/.conductor-cli/config.yaml` on every run. The removal of the default config in 87a6d26 was incomplete. The write path went away and the read path did not.

**2. Env vars and the config file merged, key by key.** E.g.: `CONDUCTOR_SERVER_URL` overrode only the server, and `config.yaml` still supplied everything else — so **one run could take its server from the environment and its auth token from a file**. 

## What changed

- **`config save` can write the default again.** 
- `default` is an alias for that file, not a profile of its own. 
- **Configuration comes from exactly one source, never a mix** (but flags override individual settings).

```bash
$ conductor config save
Profile name (empty for default):        # Enter
✓ Configuration saved to ~/.conductor-cli/config.yaml

$ conductor config save --profile default
✓ Configuration saved to ~/.conductor-cli/config.yaml    # same file
```
**Precedence:**

| Order | Source | Example |
|-------|--------|---------|
| 1 | Flags | `--server`, `--auth-token` |
| 2 | The file from `--config` or `--profile` | `--profile prod` reads `config-prod.yaml` |
| 3 | Environment variables | `CONDUCTOR_SERVER_URL` |
| 4 | The default config file | `~/.conductor-cli/config.yaml` |

So exporting `CONDUCTOR_SERVER_URL` switches everything onto the environment — a token sitting in `config.yaml` is no longer used.

**`config show` says which source is live**, and `--verbose` reports the same per key:

```
$ CONDUCTOR_SERVER_URL=http://from-env:9999/api conductor config show
Source: environment variables

KEY           VALUE                      SOURCE
server        http://from-env:9999/api   env CONDUCTOR_SERVER_URL
server-type   OSS                        default
auth-token    -                          default
```

## How to test

```bash
go build -o conductor .
export HOME=$(mktemp -d) && mkdir -p $HOME/.conductor-cli   # keep your real config safe

# 1. the default config is manageable again
printf '\n\n\n' | ./conductor config save     # Enter at the prompt
ls $HOME/.conductor-cli/                      # config.yaml
./conductor config list                       # default
./conductor config delete default -y          # gone

# 2. no merging: the file's token is not used once an env var is set
printf 'server: http://from-file:8080/api\nauth-token: tok-from-file\n' > $HOME/.conductor-cli/config.yaml
./conductor config show                                          # everything from config.yaml
CONDUCTOR_SERVER_URL=http://from-env:9999/api ./conductor config show   # env only, token absent

# 3. naming a file beats the environment
printf 'server: http://from-explicit:6666/api\n' > $HOME/explicit.yaml
CONDUCTOR_SERVER_URL=http://from-env:9999/api ./conductor --config $HOME/explicit.yaml config show

# 4. flags still override one key at a time
./conductor --server http://from-flag:1111/api config show       # token still from the file
```

## Review notes

- **`CONDUCTOR_PROFILE` doesn't count** as a setting variable — it picks a file.
- **Path resolution was duplicated in four places** (save, delete, `initConfig`, `getConfigPath`), which is how the rule drifted between them. Now in `internal/cliconfig`, and unit-testable without cobra.
- **Token caching** never persisted for the default config, because `getConfigPath("")` returned an error. It now resolves, but caching is skipped in two cases: when the environment is the active source (no file backs the run, and writing would store the token against whatever identity the file holds), and when `config.yaml` does not exist (creating it would leave a config file on an environment-only user).
- **A stray `config-default.yaml`** is warned about, never loaded.
- E2E tests for the default config use a throwaway `HOME`, so they can't clobber a real one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)








