### PR TITLE
feat: enable the workflow message queue on the local server

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -633,7 +633,7 @@ func startServer(cmd *cobra.Command, args []string) error {
 	// Enable AI integration + embedded AgentSpan by default for the local dev server.
 	// Passed as command-line args (Spring Boot's highest-precedence source) so this holds
 	// regardless of the downloaded jar's baked default; agentspan.embedded resolves from it.
-	javaArgs = append(javaArgs, aiIntegrationArgs()...)
+	javaArgs = append(javaArgs, localServerArgs()...)
 
 	serverTypeDisplay := "OSS"
 	if serverType == serverTypeOrkes {
@@ -894,16 +894,18 @@ func updateServer(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// aiIntegrationArgs returns the Spring Boot command-line args that turn on the AI
-// integration and the embedded AgentSpan runtime for the local server. These are enabled
-// by default so agentic workflows work out of the box with `conductor server start`.
-// Command-line args are Spring Boot's highest-precedence property source, so this holds
-// even if the downloaded jar was built with the feature off; agentspan.embedded resolves
-// from conductor.integrations.ai.enabled.
-func aiIntegrationArgs() []string {
+// localServerArgs returns the Spring Boot command-line args that every local server start
+// passes. They turn on the AI integration with the embedded AgentSpan runtime, and the
+// workflow message queue, so agentic workflows and workflow messaging work out of the box
+// with `conductor server start`.
+//
+// Command-line args are Spring Boot's highest-precedence property source, so these hold
+// regardless of the downloaded jar's baked defaults.
+func localServerArgs() []string {
 	return []string{
 		"--conductor.integrations.ai.enabled=true",
 		"--agentspan.embedded=true",
+		"--conductor.workflow-message-queue.enabled=true",
 	}
 }
 
@@ -978,7 +980,7 @@ func startLocalServer(port int) error {
 	}
 
 	// Enable AI integration + embedded AgentSpan by default (see startServer for rationale).
-	javaArgs = append(javaArgs, aiIntegrationArgs()...)
+	javaArgs = append(javaArgs, localServerArgs()...)
 
 	fmt.Printf("Starting OSS Conductor server (version: %s) on port %d...\n", version, port)
 

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -468,3 +468,26 @@ func TestWritePidCreatesFile(t *testing.T) {
 		t.Errorf("got pid %d, want 42", pid)
 	}
 }
+
+func TestLocalServerArgs(t *testing.T) {
+	args := localServerArgs()
+
+	want := []string{
+		"--conductor.integrations.ai.enabled=true",
+		"--agentspan.embedded=true",
+		"--conductor.workflow-message-queue.enabled=true",
+	}
+
+	for _, w := range want {
+		found := false
+		for _, got := range args {
+			if got == w {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("missing arg %q in %v", w, args)
+		}
+	}
+}


### PR DESCRIPTION
`conductor server start` now passes `--conductor.workflow-message-queue.enabled=true`. The jar ships the feature off, so workflow messaging needed manual setup on a dev server.

Test: start the server, run a workflow with a `PULL_WORKFLOW_MESSAGES` task, then `POST /api/workflow/$WF/messages`. The task consumes the message and completes. Verified against 3.32.1.


🤖 Generated with [Claude Code](https://claude.com/claude-code)